### PR TITLE
Fix CX sell order fill logic

### DIFF
--- a/src/features/XIT/ACT/action-steps/CX_SELL.ts
+++ b/src/features/XIT/ACT/action-steps/CX_SELL.ts
@@ -1,7 +1,7 @@
 import { act } from '@src/features/XIT/ACT/act-registry';
 import { fixed0, fixed02 } from '@src/utils/format';
 import { changeInputValue, clickElement } from '@src/util';
-import { fillAmount } from '@src/features/XIT/ACT/actions/cx-buy/utils';
+import { fillAmount } from '@src/features/XIT/ACT/actions/cx-sell/utils';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { isDefined } from 'ts-extras';
 import { ExchangeTickersReverse } from '@src/legacy';

--- a/src/features/XIT/ACT/actions/cx-sell/cx-sell.ts
+++ b/src/features/XIT/ACT/actions/cx-sell/cx-sell.ts
@@ -2,7 +2,7 @@ import { act } from '@src/features/XIT/ACT/act-registry';
 import Edit from '@src/features/XIT/ACT/actions/cx-buy/Edit.vue';
 import { CX_SELL } from '@src/features/XIT/ACT/action-steps/CX_SELL';
 import { fixed0, fixed02 } from '@src/utils/format';
-import { fillAmount } from '@src/features/XIT/ACT/actions/cx-buy/utils';
+import { fillAmount } from '@src/features/XIT/ACT/actions/cx-sell/utils';
 
 act.addAction({
   type: 'CX Sell',

--- a/src/features/XIT/ACT/actions/cx-sell/utils.ts
+++ b/src/features/XIT/ACT/actions/cx-sell/utils.ts
@@ -12,10 +12,12 @@ export function fillAmount(cxTicker: string, amount: number, priceLimit: number)
     priceLimit: 0,
     cost: 0,
   };
-  const orders = orderBook.sellingOrders.slice().sort((a, b) => a.limit.amount - b.limit.amount);
+  const orders = orderBook.buyingOrders
+    .slice()
+    .sort((a, b) => b.limit.amount - a.limit.amount);
   for (const order of orders) {
     const orderPrice = order.limit.amount;
-    if (priceLimit < orderPrice) {
+    if (priceLimit > orderPrice) {
       break;
     }
     const orderAmount = isFiniteOrder(order) ? order.amount : Infinity;


### PR DESCRIPTION
## Summary
- correct the fill calculation for CX sell orders
- use the local helper for sell actions

## Testing
- `npm run lint` *(fails: fetch pnpm)*
- `npm run compile` *(fails: missing types)*

------
https://chatgpt.com/codex/tasks/task_e_684822721e308325bd3cab85c55a0f21