### PR TITLE
Update CX sell messages and labels

### DIFF
--- a/src/features/XIT/ACT/action-steps/CX_SELL.ts
+++ b/src/features/XIT/ACT/action-steps/CX_SELL.ts
@@ -98,7 +98,7 @@ export const CX_SELL = act.addActionStep<Data>({
 
     if (filled.amount < amount) {
       if (!data.buyPartial) {
-        let message = `Not enough materials on ${exchange} to buy ${fixed0(amount)} ${ticker}`;
+        let message = `Not enough demand on ${exchange} to sell ${fixed0(amount)} ${ticker}`;
         if (isFinite(priceLimit)) {
           message += ` with price limit ${fixed02(priceLimit)}/u`;
         }
@@ -109,7 +109,7 @@ export const CX_SELL = act.addActionStep<Data>({
 
       const leftover = amount - filled.amount;
       let message =
-        `${fixed0(leftover)} ${ticker} will not be bought on ${exchange} ` +
+        `${fixed0(leftover)} ${ticker} will not be sold on ${exchange} ` +
         `(${fixed0(filled.amount)} of ${fixed0(amount)} available`;
       if (isFinite(priceLimit)) {
         message += ` with price limit ${fixed02(priceLimit)}/u`;

--- a/src/features/XIT/ACT/actions/cx-sell/Edit.vue
+++ b/src/features/XIT/ACT/actions/cx-sell/Edit.vue
@@ -5,7 +5,7 @@ import PrunButton from '@src/components/PrunButton.vue';
 import SelectInput from '@src/components/forms/SelectInput.vue';
 import RadioItem from '@src/components/forms/RadioItem.vue';
 import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
-import EditPriceLimits from '@src/features/XIT/ACT/actions/cx-buy/EditPriceLimits.vue';
+import EditPriceLimits from './EditPriceLimits.vue';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
 
 const { action, pkg } = defineProps<{
@@ -67,9 +67,9 @@ defineExpose({ validate, save });
     <PrunButton primary @click="onEditPriceLimitsClick">EDIT</PrunButton>
   </Commands>
   <Active
-    label="Buy Partial"
+    label="Sell Partial"
     tooltip="Whether the action will be taken if there is not enough stock on the CX.">
-    <RadioItem v-model="buyPartial">buy partial</RadioItem>
+    <RadioItem v-model="buyPartial">sell partial</RadioItem>
   </Active>
   <Active
     label="Use CX Inventory"

--- a/src/features/XIT/ACT/actions/cx-sell/cx-sell.ts
+++ b/src/features/XIT/ACT/actions/cx-sell/cx-sell.ts
@@ -1,5 +1,5 @@
 import { act } from '@src/features/XIT/ACT/act-registry';
-import Edit from '@src/features/XIT/ACT/actions/cx-buy/Edit.vue';
+import Edit from './Edit.vue';
 import { CX_SELL } from '@src/features/XIT/ACT/action-steps/CX_SELL';
 import { fixed0, fixed02 } from '@src/utils/format';
 import { fillAmount } from '@src/features/XIT/ACT/actions/cx-buy/utils';
@@ -24,7 +24,7 @@ act.addAction({
 
     const exchange = data.exchange;
     if (!exchange) {
-      log.error('Missing exchange on CX buy');
+      log.error('Missing exchange on CX sell');
     }
 
     if (!materials || !exchange) {
@@ -67,7 +67,7 @@ act.addAction({
 
       if (filled && filled.amount < amount) {
         if (!data.buyPartial) {
-          let message = `Not enough materials on ${exchange} to buy ${fixed0(amount)} ${ticker}`;
+          let message = `Not enough demand on ${exchange} to sell ${fixed0(amount)} ${ticker}`;
           if (isFinite(priceLimit)) {
             message += ` with price limit ${fixed02(priceLimit)}/u`;
           }
@@ -78,7 +78,7 @@ act.addAction({
 
         const leftover = amount - filled.amount;
         let message =
-          `${fixed0(leftover)} ${ticker} will not be bought on ${exchange} ` +
+          `${fixed0(leftover)} ${ticker} will not be sold on ${exchange} ` +
           `(${fixed0(filled.amount)} of ${fixed0(amount)} available`;
         if (isFinite(priceLimit)) {
           message += ` with price limit ${fixed02(priceLimit)}/u`;


### PR DESCRIPTION
## Summary
- update cx-sell action to use local editor
- tweak sell log messages
- rename Sell Partial label in editor

## Testing
- `npm run lint` *(fails: Request was cancelled)*
- `npm run compile` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6848227076708325bebf7aca38138802