### PR TITLE
Add production assignment UI

### DIFF
--- a/src/features/XIT/PROD/AddAssignmentOverlay.vue
+++ b/src/features/XIT/PROD/AddAssignmentOverlay.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Active from '@src/components/forms/Active.vue';
+import NumberInput from '@src/components/forms/NumberInput.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+
+const { maxAmount, onSave } = defineProps<{ maxAmount: number; onSave: (siteId: string, amount: number) => void }>();
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const siteId = ref('');
+const amount = ref(maxAmount);
+
+const options = computed(() =>
+  sitesStore.all.value?.map(site => ({
+    label: getEntityNameFromAddress(site.address),
+    value: site.siteId,
+  })) ?? []);
+
+function save() {
+  if (!siteId.value || !amount.value) {
+    return;
+  }
+  onSave(siteId.value, Math.min(amount.value, maxAmount));
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>Add Assignment</SectionHeader>
+    <form>
+      <Active label="Destination">
+        <SelectInput v-model="siteId" :options="options" />
+      </Active>
+      <Active label="Amount">
+        <NumberInput v-model="amount" :max="maxAmount" :min="1" />
+      </Active>
+      <Commands>
+        <PrunButton primary @click="save">SAVE</PrunButton>
+        <PrunButton neutral @click="emit('close')">CANCEL</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>

--- a/src/features/XIT/PROD/MaterialList.vue
+++ b/src/features/XIT/PROD/MaterialList.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { PlanetBurn } from '@src/core/burn';
+import MaterialRow from './MaterialRow.vue';
+import { sortMaterials } from '@src/core/sort-materials';
+import { isDefined } from 'ts-extras';
+
+interface Assignment { siteId: string; amount: number }
+
+const { burn, assignments } = defineProps<{ burn: PlanetBurn; assignments: Record<string, Assignment[]> }>();
+
+const materials = computed(() => Object.keys(burn.burn).map(materialsStore.getByTicker));
+const sorted = computed(() => sortMaterials(materials.value.filter(isDefined)));
+
+function onAdd(ticker: string, assignment: Assignment) {
+  if (!assignments[ticker]) {
+    assignments[ticker] = [];
+  }
+  assignments[ticker].push(assignment);
+}
+</script>
+
+<template>
+  <tr><th colspan="6">Produced</th></tr>
+  <MaterialRow
+    v-for="material in sorted.filter(m => burn.burn[m!.ticker].output > 0)"
+    :key="material!.id"
+    :burn="burn.burn[material!.ticker]"
+    :material="material!"
+    :assignments="assignments[material!.ticker] ?? []"
+    @add-assignment="a => onAdd(material!.ticker, a)" />
+  <tr><th colspan="6">Consumed</th></tr>
+  <MaterialRow
+    v-for="material in sorted.filter(m => burn.burn[m!.ticker].output <= 0)"
+    :key="material!.ticker + '-c'"
+    :burn="burn.burn[material!.ticker]"
+    :material="material!"
+    :assignments="[]" />
+</template>

--- a/src/features/XIT/PROD/MaterialRow.vue
+++ b/src/features/XIT/PROD/MaterialRow.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { MaterialBurn } from '@src/core/burn';
+import MaterialIcon from '@src/components/MaterialIcon.vue';
+import DaysCell from '@src/features/XIT/BURN/DaysCell.vue';
+import { fixed0 } from '@src/utils/format';
+import PrunButton from '@src/components/PrunButton.vue';
+import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import AddAssignmentOverlay from './AddAssignmentOverlay.vue';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+
+interface Assignment {
+  siteId: string;
+  amount: number;
+}
+
+const { burn, material, assignments } = defineProps<{ burn: MaterialBurn; material: PrunApi.Material; assignments: Assignment[] }>();
+
+const emit = defineEmits<{ (e: 'add-assignment', assignment: Assignment): void }>();
+
+const expanded = ref(false);
+
+function openAdd(ev: Event) {
+  showTileOverlay(ev, AddAssignmentOverlay, {
+    maxAmount: burn.output,
+    onSave: (siteId: string, amount: number) => emit('add-assignment', { siteId, amount }),
+  });
+}
+
+function siteName(id: string) {
+  const site = sitesStore.getById(id);
+  return site ? getEntityNameFromAddress(site.address) : id;
+}
+</script>
+
+<template>
+  <tr>
+    <td :class="$style.materialContainer">
+      <MaterialIcon size="inline-table" :ticker="material.ticker" />
+    </td>
+    <td>{{ fixed0(burn.Inventory ?? 0) }}</td>
+    <td>{{ fixed0(burn.output) }}</td>
+    <td>{{ fixed0(burn.input + burn.workforce) }}</td>
+    <DaysCell :days="burn.DaysLeft" />
+    <td>
+      <PrunButton dark inline @click="openAdd">ADD</PrunButton>
+      <span v-if="assignments.length" @click="expanded = !expanded" :class="$style.toggle">{{ expanded ? '-' : '+' }}</span>
+    </td>
+  </tr>
+  <tr v-if="expanded" v-for="(a, i) in assignments" :key="i">
+    <td colspan="6" :class="$style.assignment">
+      Transfer {{ fixed0(a.amount) }} to {{ siteName(a.siteId) }}
+    </td>
+  </tr>
+</template>
+
+<style module>
+.materialContainer {
+  width: 32px;
+  padding: 0;
+}
+.assignment {
+  padding-left: 40px;
+  font-size: 11px;
+}
+.toggle {
+  cursor: pointer;
+  margin-left: 4px;
+}
+</style>

--- a/src/features/XIT/PROD/PROD.ts
+++ b/src/features/XIT/PROD/PROD.ts
@@ -15,7 +15,7 @@ xit.add({
 
     return 'PRODUCTION ASSIGNMENTS';
   },
-  description: 'Shows the number of days of consumables left.',
+  description: 'Manage production assignments for produced materials.',
   optionalParameters: 'Planet Identifier(s)',
   component: () => PROD,
 });

--- a/src/features/XIT/PROD/PROD.vue
+++ b/src/features/XIT/PROD/PROD.vue
@@ -1,176 +1,47 @@
 <script setup lang="ts">
-import FilterButton from '@src/features/XIT/BURN/FilterButton.vue';
-import { getPlanetBurn, MaterialBurn } from '@src/core/burn';
-import { comparePlanets } from '@src/util';
-import BurnSection from '@src/features/XIT/BURN/BurnSection.vue';
-import { useTileState } from '@src/features/XIT/BURN/tile-state';
-import Tooltip from '@src/components/Tooltip.vue';
-import LoadingSpinner from '@src/components/LoadingSpinner.vue';
-import MaterialRow from '@src/features/XIT/BURN/MaterialRow.vue';
-import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { computed, reactive } from 'vue';
+import { getPlanetBurn } from '@src/core/burn';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { useXitParameters } from '@src/hooks/use-xit-parameters';
 import { isDefined, isEmpty } from 'ts-extras';
-import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
-import { countDays } from '@src/features/XIT/BURN/utils';
-import Active from '@src/components/forms/Active.vue';
-import TextInput from '@src/components/forms/TextInput.vue';
-import PrunButton from '@src/components/PrunButton.vue';
-import Passive from '@src/components/forms/Passive.vue';
+import LoadingSpinner from '@src/components/LoadingSpinner.vue';
+import PlanetSection from './PlanetSection.vue';
 
 const parameters = useXitParameters();
-const isBurnAll = isEmpty(parameters) || parameters[0].toLowerCase() == 'all';
+const isAll = isEmpty(parameters) || parameters[0].toLowerCase() === 'all';
 
 const sites = computed(() => {
-  if (isBurnAll) {
+  if (isAll) {
     return sitesStore.all.value;
   }
-
   return parameters.map(x => sitesStore.getByPlanetNaturalIdOrName(x)).filter(isDefined);
 });
 
-const planetBurn = computed(() => {
-  const filtered = sites.value!.map(getPlanetBurn).filter(isDefined);
-  if (filtered.length <= 1) {
-    return filtered;
-  }
+const planetBurn = computed(() => sites.value?.map(getPlanetBurn).filter(isDefined) ?? []);
 
-  filtered.sort((a, b) => {
-    const daysA = countDays(a.burn);
-    const daysB = countDays(b.burn);
-    if (daysA !== daysB) {
-      return daysA - daysB;
-    }
-    return comparePlanets(a.naturalId, b.naturalId);
-  });
-
-  const overallBurn = {};
-  for (const burn of filtered) {
-    for (const mat of Object.keys(burn.burn)) {
-      if (overallBurn[mat]) {
-        overallBurn[mat].DailyAmount += burn.burn[mat].DailyAmount;
-        overallBurn[mat].Inventory += burn.burn[mat].Inventory;
-      } else {
-        overallBurn[mat] = {};
-        overallBurn[mat].DailyAmount = burn.burn[mat].DailyAmount;
-        overallBurn[mat].Inventory = burn.burn[mat].Inventory;
-      }
-    }
-  }
-
-  for (const mat of Object.keys(overallBurn)) {
-    if (overallBurn[mat].DailyAmount >= 0) {
-      overallBurn[mat].DaysLeft = 1000;
-    } else {
-      overallBurn[mat].DaysLeft = -overallBurn[mat].Inventory / overallBurn[mat].DailyAmount;
-    }
-  }
-
-  filtered.push({ burn: overallBurn, planetName: 'Overall', naturalId: '', storeId: '' });
-  return filtered;
-});
-
-const red = useTileState('red');
-const yellow = useTileState('yellow');
-const green = useTileState('green');
-const inf = useTileState('inf');
-
-const materialFilter = useTileState('materialFilter');
-
-const fakeBurn: MaterialBurn = {
-  DailyAmount: -100000,
-  DaysLeft: 10,
-  Inventory: 100000,
-  Type: 'input',
-  input: 100000,
-  output: 0,
-  workforce: 0,
-};
-
-const rat = materialsStore.getByTicker('RAT');
-
-const expand = useTileState('expand');
-
-const anyExpanded = computed(() => expand.value.length > 0);
-
-function onExpandAllClick() {
-  if (expand.value.length > 0) {
-    expand.value = [];
-  } else {
-    expand.value = planetBurn.value.map(x => x.naturalId);
-  }
-}
+const assignments = reactive<Record<string, Record<string, any>>>({});
 </script>
 
 <template>
   <LoadingSpinner v-if="sites === undefined" />
   <template v-else>
-    <div :class="C.ComExOrdersPanel.filter">
-      <FilterButton v-model="red">RED</FilterButton>
-      <FilterButton v-model="yellow">YELLOW</FilterButton>
-      <FilterButton v-model="green">GREEN</FilterButton>
-      <FilterButton v-model="inf">INF</FilterButton>
-        <Passive label="Filter:">
-            <TextInput v-model="materialFilter" dark />
-        </Passive>
-    </div>
     <table>
       <thead>
         <tr>
-          <th v-if="sites.length > 0" :class="$style.expand" @click="onExpandAllClick">
-            {{ anyExpanded ? '-' : '+' }}
-          </th>
-          <th v-else />
+          <th>Mat</th>
           <th>Inv</th>
-          <th>
-            <div :class="$style.header">
-              Burn
-              <Tooltip position="bottom" tooltip="How much of a material is consumed per day." />
-            </div>
-          </th>
-          <th>
-            <div :class="$style.header">
-              Need
-              <Tooltip
-                position="bottom"
-                tooltip="How much of a material needs to be delivered to be fully supplied." />
-            </div>
-          </th>
+          <th>Prod</th>
+          <th>Cons</th>
           <th>Days</th>
-          <th>CMD</th>
+          <th />
         </tr>
       </thead>
-      <tbody :class="$style.fakeRow">
-        <MaterialRow always-visible :burn="fakeBurn" :material="rat" />
-      </tbody>
-      
-      <BurnSection
+      <PlanetSection
         v-for="burn in planetBurn"
-        :key="burn.planetName"
-        :can-minimize="sites.length > 1"
-        :burn="burn" />
-
-
+        :key="burn.naturalId"
+        :burn="burn"
+        :assignments="assignments[burn.storeId] ??= {}"
+        :can-minimize="planetBurn.length > 1" />
     </table>
   </template>
 </template>
-
-<style module>
-.fakeRow {
-  visibility: collapse;
-}
-
-.header {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.expand {
-  text-align: center;
-  cursor: pointer;
-  user-select: none;
-  font-size: 12px;
-  padding-left: 18px;
-  font-weight: bold;
-}
-</style>

--- a/src/features/XIT/PROD/PlanetSection.vue
+++ b/src/features/XIT/PROD/PlanetSection.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { PlanetBurn } from '@src/core/burn';
+import PlanetHeader from '@src/features/XIT/BURN/PlanetHeader.vue';
+import MaterialList from './MaterialList.vue';
+
+const { burn, assignments, canMinimize } = defineProps<{ burn: PlanetBurn; assignments: Record<string, any>; canMinimize?: boolean }>();
+
+const expanded = ref(true);
+
+function toggle() {
+  if (!canMinimize) return;
+  expanded.value = !expanded.value;
+}
+</script>
+
+<template>
+  <tbody>
+    <PlanetHeader :has-minimize="canMinimize" :burn="burn" :minimized="!expanded" :on-click="toggle" />
+  </tbody>
+  <tbody v-if="expanded">
+    <MaterialList :burn="burn" :assignments="assignments" />
+  </tbody>
+</template>


### PR DESCRIPTION
## Summary
- implement a basic overlay to create material assignments
- add per-material assignment rows and listing
- show planet sections with produced and consumed goods
- wire up PROD command description

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `npm run compile` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68484f02cac0832591618e30ce0ee644