### PR TITLE
Refine production assignment UI

### DIFF
--- a/src/features/XIT/PROD/AddAssignmentOverlay.vue
+++ b/src/features/XIT/PROD/AddAssignmentOverlay.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Active from '@src/components/forms/Active.vue';
+import NumberInput from '@src/components/forms/NumberInput.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { getPlanetBurn } from '@src/core/burn';
+import { fixed0 } from '@src/utils/format';
+
+const { maxAmount, ticker, onSave } = defineProps<{
+  maxAmount: number;
+  ticker: string;
+  onSave: (siteId: string, amount: number) => void;
+}>();
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const siteId = ref('');
+const amount = ref(maxAmount);
+
+const options = computed(() =>
+  sitesStore.all.value?.map(site => {
+    const burn = getPlanetBurn(site.siteId);
+    const b = burn?.burn[ticker];
+    const net = b ? b.output - b.input - b.workforce : 0;
+    const deficit = net < 0 ? -net : 0;
+    return {
+      label:
+        getEntityNameFromAddress(site.address) +
+        (deficit > 0 ? ` (-${fixed0(deficit)})` : ''),
+      value: site.siteId,
+    };
+  }) ?? []);
+
+function save() {
+  if (!siteId.value || !amount.value) {
+    return;
+  }
+  onSave(siteId.value, Math.min(amount.value, maxAmount));
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>Add Assignment</SectionHeader>
+    <form>
+      <Active label="Destination">
+        <SelectInput v-model="siteId" :options="options" />
+      </Active>
+      <Active label="Amount">
+        <NumberInput v-model="amount" :max="maxAmount" :min="1" />
+      </Active>
+      <Commands>
+        <PrunButton primary @click="save">SAVE</PrunButton>
+        <PrunButton neutral @click="emit('close')">CANCEL</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>

--- a/src/features/XIT/PROD/MaterialList.vue
+++ b/src/features/XIT/PROD/MaterialList.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { PlanetBurn } from '@src/core/burn';
+import MaterialRow from './MaterialRow.vue';
+import { sortMaterials } from '@src/core/sort-materials';
+import { isDefined } from 'ts-extras';
+
+interface Assignment {
+  siteId: string;
+  amount: number;
+}
+
+const emit = defineEmits<{
+  (e: 'add-assignment', ticker: string, siteId: string, amount: number): void;
+}>();
+
+const { burn, assignments } = defineProps<{
+  burn: PlanetBurn;
+  assignments: Record<string, Assignment[]>;
+}>();
+
+const materials = computed(() => Object.keys(burn.burn).map(materialsStore.getByTicker));
+const sorted = computed(() => sortMaterials(materials.value.filter(isDefined)));
+
+function visible(material: PrunApi.Material | undefined) {
+  if (!material) return false;
+  const b = burn.burn[material.ticker];
+  return b.output !== 0 || b.input !== 0;
+}
+
+const produced = computed(() =>
+  sorted.value.filter(m => m && burn.burn[m.ticker].output > 0 && visible(m!)),
+);
+const consumed = computed(() =>
+  sorted.value.filter(
+    m =>
+      m &&
+      burn.burn[m.ticker].output <= 0 &&
+      (burn.burn[m.ticker].input > 0 || burn.burn[m.ticker].workforce > 0),
+  ),
+);
+
+function onAdd(ticker: string, siteId: string, amount: number) {
+  emit('add-assignment', ticker, siteId, amount);
+}
+</script>
+
+<template>
+  <tr><th colspan="7">Produced</th></tr>
+  <MaterialRow
+    v-for="material in produced"
+    :key="material!.id"
+    :burn="burn.burn[material!.ticker]"
+    :material="material!"
+    :assignments="assignments[material!.ticker] ?? []"
+    @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)" />
+  <tr><th colspan="7">Consumed</th></tr>
+  <MaterialRow
+    v-for="material in consumed"
+    :key="material!.ticker + '-c'"
+    :burn="burn.burn[material!.ticker]"
+    :material="material!"
+    :assignments="assignments[material!.ticker] ?? []"
+    @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)" />
+</template>

--- a/src/features/XIT/PROD/MaterialRow.vue
+++ b/src/features/XIT/PROD/MaterialRow.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { MaterialBurn } from '@src/core/burn';
+import MaterialIcon from '@src/components/MaterialIcon.vue';
+import { fixed0 } from '@src/utils/format';
+import PrunButton from '@src/components/PrunButton.vue';
+import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import AddAssignmentOverlay from './AddAssignmentOverlay.vue';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+
+interface Assignment {
+  siteId: string;
+  amount: number;
+}
+
+const { burn, material, assignments } = defineProps<{
+  burn: MaterialBurn;
+  material: PrunApi.Material;
+  assignments: Assignment[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'add-assignment', siteId: string, amount: number): void;
+}>();
+
+const expanded = ref(false);
+
+const transfer = computed(() => assignments.reduce((a, b) => a + b.amount, 0));
+const sum = computed(
+  () => (burn.Inventory ?? 0) + burn.output - burn.input - burn.workforce + transfer.value,
+);
+
+function openAdd(ev: Event) {
+  showTileOverlay(ev, AddAssignmentOverlay, {
+    maxAmount: burn.output,
+    ticker: material.ticker,
+    onSave: (siteId: string, amount: number) => emit('add-assignment', siteId, amount),
+  });
+}
+
+function siteName(id: string) {
+  const site = sitesStore.getById(id);
+  return site ? getEntityNameFromAddress(site.address) : id;
+}
+</script>
+
+<template>
+  <tr @click="assignments.length && (expanded = !expanded)">
+    <td :class="$style.materialContainer">
+      <MaterialIcon size="inline-table" :ticker="material.ticker" />
+    </td>
+    <td>{{ fixed0(burn.Inventory ?? 0) }}</td>
+    <td>{{ fixed0(burn.input + burn.workforce) }}</td>
+    <td>{{ fixed0(burn.output) }}</td>
+    <td :class="{ [C.ColoredValue.positive]: transfer > 0, [C.ColoredValue.negative]: transfer < 0 }">
+      {{ fixed0(transfer) }}
+    </td>
+    <td>{{ fixed0(sum) }}</td>
+    <td>
+      <PrunButton dark inline @click.stop="openAdd">ADD</PrunButton>
+    </td>
+  </tr>
+  <tr v-if="expanded" v-for="(a, i) in assignments" :key="i">
+    <td colspan="7" :class="$style.assignment">
+      {{ a.amount > 0 ? 'Import' : 'Export' }} {{ fixed0(Math.abs(a.amount)) }}
+      {{ a.amount > 0 ? 'from' : 'to' }} {{ siteName(a.siteId) }}
+    </td>
+  </tr>
+</template>
+
+<style module>
+.materialContainer {
+  width: 32px;
+  padding: 0;
+}
+.assignment {
+  padding-left: 40px;
+  font-size: 11px;
+}
+</style>

--- a/src/features/XIT/PROD/PROD.ts
+++ b/src/features/XIT/PROD/PROD.ts
@@ -15,7 +15,7 @@ xit.add({
 
     return 'PRODUCTION ASSIGNMENTS';
   },
-  description: 'Shows the number of days of consumables left.',
+  description: 'Manage production assignments for produced materials.',
   optionalParameters: 'Planet Identifier(s)',
   component: () => PROD,
 });

--- a/src/features/XIT/PROD/PROD.vue
+++ b/src/features/XIT/PROD/PROD.vue
@@ -1,176 +1,59 @@
 <script setup lang="ts">
-import FilterButton from '@src/features/XIT/BURN/FilterButton.vue';
-import { getPlanetBurn, MaterialBurn } from '@src/core/burn';
-import { comparePlanets } from '@src/util';
-import BurnSection from '@src/features/XIT/BURN/BurnSection.vue';
-import { useTileState } from '@src/features/XIT/BURN/tile-state';
-import Tooltip from '@src/components/Tooltip.vue';
-import LoadingSpinner from '@src/components/LoadingSpinner.vue';
-import MaterialRow from '@src/features/XIT/BURN/MaterialRow.vue';
-import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { computed, reactive } from 'vue';
+import { getPlanetBurn } from '@src/core/burn';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { useXitParameters } from '@src/hooks/use-xit-parameters';
 import { isDefined, isEmpty } from 'ts-extras';
-import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
-import { countDays } from '@src/features/XIT/BURN/utils';
-import Active from '@src/components/forms/Active.vue';
-import TextInput from '@src/components/forms/TextInput.vue';
-import PrunButton from '@src/components/PrunButton.vue';
-import Passive from '@src/components/forms/Passive.vue';
+import LoadingSpinner from '@src/components/LoadingSpinner.vue';
+import PlanetSection from './PlanetSection.vue';
 
 const parameters = useXitParameters();
-const isBurnAll = isEmpty(parameters) || parameters[0].toLowerCase() == 'all';
+const isAll = isEmpty(parameters) || parameters[0].toLowerCase() === 'all';
 
 const sites = computed(() => {
-  if (isBurnAll) {
+  if (isAll) {
     return sitesStore.all.value;
   }
-
   return parameters.map(x => sitesStore.getByPlanetNaturalIdOrName(x)).filter(isDefined);
 });
 
-const planetBurn = computed(() => {
-  const filtered = sites.value!.map(getPlanetBurn).filter(isDefined);
-  if (filtered.length <= 1) {
-    return filtered;
-  }
+const planetBurn = computed(() => sites.value?.map(getPlanetBurn).filter(isDefined) ?? []);
 
-  filtered.sort((a, b) => {
-    const daysA = countDays(a.burn);
-    const daysB = countDays(b.burn);
-    if (daysA !== daysB) {
-      return daysA - daysB;
-    }
-    return comparePlanets(a.naturalId, b.naturalId);
-  });
+const assignments = reactive<Record<string, Record<string, { siteId: string; amount: number }[]>>>({});
 
-  const overallBurn = {};
-  for (const burn of filtered) {
-    for (const mat of Object.keys(burn.burn)) {
-      if (overallBurn[mat]) {
-        overallBurn[mat].DailyAmount += burn.burn[mat].DailyAmount;
-        overallBurn[mat].Inventory += burn.burn[mat].Inventory;
-      } else {
-        overallBurn[mat] = {};
-        overallBurn[mat].DailyAmount = burn.burn[mat].DailyAmount;
-        overallBurn[mat].Inventory = burn.burn[mat].Inventory;
-      }
-    }
-  }
+function addAssignment(from: string, ticker: string, to: string, amount: number) {
+  const src = (assignments[from] ??= {});
+  const srcTicker = (src[ticker] ??= []);
+  srcTicker.push({ siteId: to, amount: -amount });
 
-  for (const mat of Object.keys(overallBurn)) {
-    if (overallBurn[mat].DailyAmount >= 0) {
-      overallBurn[mat].DaysLeft = 1000;
-    } else {
-      overallBurn[mat].DaysLeft = -overallBurn[mat].Inventory / overallBurn[mat].DailyAmount;
-    }
-  }
-
-  filtered.push({ burn: overallBurn, planetName: 'Overall', naturalId: '', storeId: '' });
-  return filtered;
-});
-
-const red = useTileState('red');
-const yellow = useTileState('yellow');
-const green = useTileState('green');
-const inf = useTileState('inf');
-
-const materialFilter = useTileState('materialFilter');
-
-const fakeBurn: MaterialBurn = {
-  DailyAmount: -100000,
-  DaysLeft: 10,
-  Inventory: 100000,
-  Type: 'input',
-  input: 100000,
-  output: 0,
-  workforce: 0,
-};
-
-const rat = materialsStore.getByTicker('RAT');
-
-const expand = useTileState('expand');
-
-const anyExpanded = computed(() => expand.value.length > 0);
-
-function onExpandAllClick() {
-  if (expand.value.length > 0) {
-    expand.value = [];
-  } else {
-    expand.value = planetBurn.value.map(x => x.naturalId);
-  }
+  const dest = (assignments[to] ??= {});
+  const destTicker = (dest[ticker] ??= []);
+  destTicker.push({ siteId: from, amount });
 }
 </script>
 
 <template>
   <LoadingSpinner v-if="sites === undefined" />
   <template v-else>
-    <div :class="C.ComExOrdersPanel.filter">
-      <FilterButton v-model="red">RED</FilterButton>
-      <FilterButton v-model="yellow">YELLOW</FilterButton>
-      <FilterButton v-model="green">GREEN</FilterButton>
-      <FilterButton v-model="inf">INF</FilterButton>
-        <Passive label="Filter:">
-            <TextInput v-model="materialFilter" dark />
-        </Passive>
-    </div>
     <table>
       <thead>
         <tr>
-          <th v-if="sites.length > 0" :class="$style.expand" @click="onExpandAllClick">
-            {{ anyExpanded ? '-' : '+' }}
-          </th>
-          <th v-else />
+          <th>Mat</th>
           <th>Inv</th>
-          <th>
-            <div :class="$style.header">
-              Burn
-              <Tooltip position="bottom" tooltip="How much of a material is consumed per day." />
-            </div>
-          </th>
-          <th>
-            <div :class="$style.header">
-              Need
-              <Tooltip
-                position="bottom"
-                tooltip="How much of a material needs to be delivered to be fully supplied." />
-            </div>
-          </th>
-          <th>Days</th>
-          <th>CMD</th>
+          <th>Input</th>
+          <th>Output</th>
+          <th>Transfer</th>
+          <th>Sum</th>
+          <th />
         </tr>
       </thead>
-      <tbody :class="$style.fakeRow">
-        <MaterialRow always-visible :burn="fakeBurn" :material="rat" />
-      </tbody>
-      
-      <BurnSection
+      <PlanetSection
         v-for="burn in planetBurn"
-        :key="burn.planetName"
-        :can-minimize="sites.length > 1"
-        :burn="burn" />
-
-
+        :key="burn.naturalId"
+        :burn="burn"
+        :assignments="assignments[burn.storeId] ??= {}"
+        :can-minimize="planetBurn.length > 1"
+        @add-assignment="addAssignment" />
     </table>
   </template>
 </template>
-
-<style module>
-.fakeRow {
-  visibility: collapse;
-}
-
-.header {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.expand {
-  text-align: center;
-  cursor: pointer;
-  user-select: none;
-  font-size: 12px;
-  padding-left: 18px;
-  font-weight: bold;
-}
-</style>

--- a/src/features/XIT/PROD/PlanetSection.vue
+++ b/src/features/XIT/PROD/PlanetSection.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { PlanetBurn } from '@src/core/burn';
+import PlanetHeader from '@src/features/XIT/BURN/PlanetHeader.vue';
+import MaterialList from './MaterialList.vue';
+
+const emit = defineEmits<{
+  (
+    e: 'add-assignment',
+    from: string,
+    ticker: string,
+    to: string,
+    amount: number,
+  ): void;
+}>();
+
+const { burn, assignments, canMinimize } = defineProps<{
+  burn: PlanetBurn;
+  assignments: Record<string, any>;
+  canMinimize?: boolean;
+}>();
+
+const expanded = ref(true);
+
+function toggle() {
+  if (!canMinimize) return;
+  expanded.value = !expanded.value;
+}
+</script>
+
+<template>
+  <tbody>
+    <PlanetHeader :has-minimize="canMinimize" :burn="burn" :minimized="!expanded" :on-click="toggle" />
+  </tbody>
+  <tbody v-if="expanded">
+    <MaterialList
+      :burn="burn"
+      :assignments="assignments"
+      @add-assignment="(t, s, a) => emit('add-assignment', burn.storeId, t, s, a)"
+    />
+  </tbody>
+</template>


### PR DESCRIPTION
## Summary
- show import/export per material with new column layout
- allow clicking rows to toggle assignment details
- highlight sites with deficits in the assignment dialog
- emit assignments to both source and destination planets

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `npm run compile` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68484f02cac0832591618e30ce0ee644