### PR TITLE
Add import/export to PROD view

### DIFF
--- a/src/features/XIT/PROD/AddAssignmentOverlay.vue
+++ b/src/features/XIT/PROD/AddAssignmentOverlay.vue
@@ -10,16 +10,20 @@ import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addr
 import { getPlanetBurn } from '@src/core/burn';
 import { fixed0 } from '@src/utils/format';
 
-const { maxAmount, ticker, onSave } = defineProps<{
+const { maxAmount, ticker, onSave, direction = 'export' } = defineProps<{
   maxAmount: number;
   ticker: string;
   onSave: (siteId: string, amount: number) => void;
+  direction?: 'export' | 'import';
 }>();
 
 const emit = defineEmits<{ (e: 'close'): void }>();
 
 const siteId = ref('');
 const amount = ref(maxAmount);
+
+const siteLabel = computed(() => (direction === 'export' ? 'Destination' : 'Source'));
+const title = computed(() => (direction === 'export' ? 'Add Export' : 'Add Import'));
 
 const options = computed(() =>
   sitesStore.all.value?.map(site => {
@@ -46,9 +50,9 @@ function save() {
 
 <template>
   <div :class="C.DraftConditionEditor.form">
-    <SectionHeader>Add Assignment</SectionHeader>
+    <SectionHeader>{{ title }}</SectionHeader>
     <form>
-      <Active label="Destination">
+      <Active :label="siteLabel">
         <SelectInput v-model="siteId" :options="options" />
       </Active>
       <Active label="Amount">

--- a/src/features/XIT/PROD/MaterialList.vue
+++ b/src/features/XIT/PROD/MaterialList.vue
@@ -12,6 +12,7 @@ interface Assignment {
 
 const emit = defineEmits<{
   (e: 'add-assignment', ticker: string, siteId: string, amount: number): void;
+  (e: 'import-assignment', ticker: string, siteId: string, amount: number): void;
 }>();
 
 const { burn, assignments } = defineProps<{
@@ -41,6 +42,10 @@ const consumed = computed(() =>
 function onAdd(ticker: string, siteId: string, amount: number) {
   emit('add-assignment', ticker, siteId, amount);
 }
+
+function onImport(ticker: string, siteId: string, amount: number) {
+  emit('import-assignment', ticker, siteId, amount);
+}
 </script>
 
 <template>
@@ -51,7 +56,8 @@ function onAdd(ticker: string, siteId: string, amount: number) {
     :burn="burn.burn[material!.ticker]"
     :material="material!"
     :assignments="assignments[material!.ticker] ?? []"
-    @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)" />
+    @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)"
+    @import-assignment="(s, amt) => onImport(material!.ticker, s, amt)" />
   <tr><th colspan="7">Consumed</th></tr>
   <MaterialRow
     v-for="material in consumed"
@@ -59,5 +65,6 @@ function onAdd(ticker: string, siteId: string, amount: number) {
     :burn="burn.burn[material!.ticker]"
     :material="material!"
     :assignments="assignments[material!.ticker] ?? []"
-    @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)" />
+    @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)"
+    @import-assignment="(s, amt) => onImport(material!.ticker, s, amt)" />
 </template>

--- a/src/features/XIT/PROD/MaterialRow.vue
+++ b/src/features/XIT/PROD/MaterialRow.vue
@@ -21,6 +21,7 @@ const { burn, material, assignments } = defineProps<{
 
 const emit = defineEmits<{
   (e: 'add-assignment', siteId: string, amount: number): void;
+  (e: 'import-assignment', siteId: string, amount: number): void;
 }>();
 
 const expanded = ref(false);
@@ -36,11 +37,26 @@ const sum = computed(
   () => burn.output - (burn.input + burn.workforce) + transfer.value,
 );
 
+const sumClass = computed(() => ({
+  [C.ColoredValue.positive]: sum.value > 0,
+  [C.ColoredValue.negative]: sum.value < 0,
+}));
+
 function openAdd(ev: Event) {
   showTileOverlay(ev, AddAssignmentOverlay, {
     maxAmount: burn.output,
     ticker: material.ticker,
+    direction: 'export',
     onSave: (siteId: string, amount: number) => emit('add-assignment', siteId, amount),
+  });
+}
+
+function openImport(ev: Event) {
+  showTileOverlay(ev, AddAssignmentOverlay, {
+    maxAmount: Math.abs(sum.value),
+    ticker: material.ticker,
+    direction: 'import',
+    onSave: (siteId: string, amount: number) => emit('import-assignment', siteId, amount),
   });
 }
 
@@ -63,9 +79,10 @@ function siteName(id: string) {
     <td :class="C.ColoredValue.positive">+{{ fixed0(burn.output) }}</td>
     <td>{{ fixed0(importTotal) }}</td>
     <td>{{ fixed0(exportTotal) }}</td>
-    <td>{{ fixed0(sum) }}</td>
+    <td :class="sumClass">{{ fixed0(sum) }}</td>
     <td>
-      <PrunButton dark inline @click.stop="openAdd">ADD</PrunButton>
+      <PrunButton dark inline @click.stop="openImport">IMPORT</PrunButton>
+      <PrunButton dark inline @click.stop="openAdd">EXPORT</PrunButton>
     </td>
   </tr>
   <tr v-if="expanded" v-for="(a, i) in assignments" :key="i">
@@ -89,5 +106,6 @@ function siteName(id: string) {
 .assignment {
   padding-left: 40px;
   font-size: 11px;
+  text-align: left;
 }
 </style>

--- a/src/features/XIT/PROD/PROD.vue
+++ b/src/features/XIT/PROD/PROD.vue
@@ -30,6 +30,10 @@ function addAssignment(from: string, ticker: string, to: string, amount: number)
   const destTicker = (dest[ticker] ??= []);
   destTicker.push({ siteId: from, amount });
 }
+
+function importAssignment(from: string, ticker: string, to: string, amount: number) {
+  addAssignment(from, ticker, to, amount);
+}
 </script>
 
 <template>
@@ -53,7 +57,8 @@ function addAssignment(from: string, ticker: string, to: string, amount: number)
         :burn="burn"
         :assignments="assignments[burn.storeId] ??= {}"
         :can-minimize="planetBurn.length > 1"
-        @add-assignment="addAssignment" />
+        @add-assignment="addAssignment"
+        @import-assignment="importAssignment" />
     </table>
   </template>
 </template>

--- a/src/features/XIT/PROD/PlanetSection.vue
+++ b/src/features/XIT/PROD/PlanetSection.vue
@@ -11,6 +11,13 @@ const emit = defineEmits<{
     to: string,
     amount: number,
   ): void;
+  (
+    e: 'import-assignment',
+    from: string,
+    ticker: string,
+    to: string,
+    amount: number,
+  ): void;
 }>();
 
 const { burn, assignments, canMinimize } = defineProps<{
@@ -36,6 +43,7 @@ function toggle() {
       :burn="burn"
       :assignments="assignments"
       @add-assignment="(t, s, a) => emit('add-assignment', burn.storeId, t, s, a)"
+      @import-assignment="(t, s, a) => emit('import-assignment', s, t, burn.storeId, a)"
     />
   </tbody>
 </template>


### PR DESCRIPTION
## Summary
- rename Add to Export and add Import button in PROD material table
- color Sum column red/green
- allow specifying direction in assignment overlay
- ensure assignment rows are left-aligned

## Testing
- `pnpm build` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68485c0c60f88325a84f22c20f912c1b