### PR TITLE
Add balance bar to production overview

### DIFF
--- a/src/components/BalanceBar.vue
+++ b/src/components/BalanceBar.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+const { value } = defineProps<{ value: number }>();
+const classes = computed(() => ({
+  [$style.good]: value > 0,
+  [$style.danger]: value < 0,
+  [$style.warning]: value === 0,
+}));
+</script>
+
+<template>
+  <div :class="[$style.bar, classes]" />
+</template>
+
+<style module>
+.bar {
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--rp-color-disabled);
+}
+.good {
+  background: var(--rp-color-green);
+}
+.danger {
+  background: var(--rp-color-red);
+}
+.warning {
+  background: var(--rp-color-accent-primary);
+}
+</style>

--- a/src/features/XIT/PROD/MaterialList.vue
+++ b/src/features/XIT/PROD/MaterialList.vue
@@ -49,7 +49,7 @@ function onImport(ticker: string, siteId: string, amount: number) {
 </script>
 
 <template>
-  <tr><th colspan="7">Produced</th></tr>
+  <tr><th colspan="8">Produced</th></tr>
   <MaterialRow
     v-for="material in produced"
     :key="material!.id"
@@ -58,7 +58,7 @@ function onImport(ticker: string, siteId: string, amount: number) {
     :assignments="assignments[material!.ticker] ?? []"
     @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)"
     @import-assignment="(s, amt) => onImport(material!.ticker, s, amt)" />
-  <tr><th colspan="7">Consumed</th></tr>
+  <tr><th colspan="8">Consumed</th></tr>
   <MaterialRow
     v-for="material in consumed"
     :key="material!.ticker + '-c'"

--- a/src/features/XIT/PROD/MaterialRow.vue
+++ b/src/features/XIT/PROD/MaterialRow.vue
@@ -3,6 +3,7 @@ import { MaterialBurn } from '@src/core/burn';
 import MaterialIcon from '@src/components/MaterialIcon.vue';
 import { fixed0 } from '@src/utils/format';
 import PrunButton from '@src/components/PrunButton.vue';
+import BalanceBar from '@src/components/BalanceBar.vue';
 import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
 import AddAssignmentOverlay from './AddAssignmentOverlay.vue';
 import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
@@ -80,6 +81,7 @@ function siteName(id: string) {
     <td>{{ fixed0(importTotal) }}</td>
     <td>{{ fixed0(exportTotal) }}</td>
     <td :class="sumClass">{{ fixed0(sum) }}</td>
+    <td><BalanceBar :value="sum" /></td>
     <td>
       <PrunButton dark inline @click.stop="openImport">IMPORT</PrunButton>
       <PrunButton dark inline @click.stop="openAdd">EXPORT</PrunButton>
@@ -91,6 +93,7 @@ function siteName(id: string) {
     <td :class="$style.assignment">{{ a.amount < 0 ? siteName(a.siteId) : '' }}</td>
     <td :class="$style.assignment">{{ a.amount > 0 ? fixed0(a.amount) : '' }}</td>
     <td :class="$style.assignment">{{ a.amount < 0 ? fixed0(-a.amount) : '' }}</td>
+    <td :class="$style.assignment"></td>
     <td :class="$style.assignment"></td>
     <td :class="$style.assignment">
       <PrunButton danger dark inline @click.stop="removeAssignment(i)">DEL</PrunButton>

--- a/src/features/XIT/PROD/PROD.vue
+++ b/src/features/XIT/PROD/PROD.vue
@@ -48,6 +48,7 @@ function importAssignment(from: string, ticker: string, to: string, amount: numb
           <th>Import</th>
           <th>Export</th>
           <th>Sum</th>
+          <th>Balance</th>
           <th />
         </tr>
       </thead>


### PR DESCRIPTION
## Summary
- show per-material balance bar
- update headers to include the new balance column

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*
- `pnpm compile` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68492d9d88cc8325bff3f4f9144af191