### PR TITLE
Improve import assignment dialog

### DIFF
--- a/src/features/XIT/PROD/MaterialRow.vue
+++ b/src/features/XIT/PROD/MaterialRow.vue
@@ -76,11 +76,15 @@ function siteName(id: string) {
     <td class="materialContainer">
       <MaterialIcon size="inline-table" :ticker="material.ticker" />
     </td>
-    <td :class="C.ColoredValue.negative">-{{ fixed0(burn.input + burn.workforce) }}</td>
-    <td :class="C.ColoredValue.positive">+{{ fixed0(burn.output) }}</td>
-    <td>{{ fixed0(importTotal) }}</td>
-    <td>{{ fixed0(exportTotal) }}</td>
-    <td :class="sumClass">{{ fixed0(sum) }}</td>
+    <td :class="C.ColoredValue.negative">
+      {{ burn.input + burn.workforce === 0 ? '' : '-' + fixed0(burn.input + burn.workforce) }}
+    </td>
+    <td :class="C.ColoredValue.positive">
+      {{ burn.output === 0 ? '' : '+' + fixed0(burn.output) }}
+    </td>
+    <td>{{ importTotal === 0 ? '' : fixed0(importTotal) }}</td>
+    <td>{{ exportTotal === 0 ? '' : fixed0(exportTotal) }}</td>
+    <td :class="sumClass">{{ sum === 0 ? '' : fixed0(sum) }}</td>
     <td><BalanceBar :value="sum" /></td>
     <td>
       <PrunButton dark inline @click.stop="openImport">IMPORT</PrunButton>


### PR DESCRIPTION
## Summary
- show surplus sources in table for import dialog
- hide zero values in production table

## Testing
- `pnpm lint` *(fails: Error when performing the request to registry)*
- `pnpm compile` *(fails: Error when performing the request to registry)*

------
https://chatgpt.com/codex/tasks/task_e_684932fb08dc8325960e2d991e26a4e9