### PR TITLE
Improve import/export overlay

### DIFF
--- a/src/features/XIT/PROD/MaterialList.vue
+++ b/src/features/XIT/PROD/MaterialList.vue
@@ -15,9 +15,10 @@ const emit = defineEmits<{
   (e: 'import-assignment', ticker: string, siteId: string, amount: number): void;
 }>();
 
-const { burn, assignments } = defineProps<{
+const { burn, assignments, siteId } = defineProps<{
   burn: PlanetBurn;
   assignments: Record<string, Assignment[]>;
+  siteId: string;
 }>();
 
 const materials = computed(() => Object.keys(burn.burn).map(materialsStore.getByTicker));
@@ -56,6 +57,7 @@ function onImport(ticker: string, siteId: string, amount: number) {
     :burn="burn.burn[material!.ticker]"
     :material="material!"
     :assignments="assignments[material!.ticker] ?? []"
+    :site-id="siteId"
     @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)"
     @import-assignment="(s, amt) => onImport(material!.ticker, s, amt)" />
   <tr><th colspan="8">Consumed</th></tr>
@@ -65,6 +67,7 @@ function onImport(ticker: string, siteId: string, amount: number) {
     :burn="burn.burn[material!.ticker]"
     :material="material!"
     :assignments="assignments[material!.ticker] ?? []"
+    :site-id="siteId"
     @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)"
     @import-assignment="(s, amt) => onImport(material!.ticker, s, amt)" />
 </template>

--- a/src/features/XIT/PROD/MaterialRow.vue
+++ b/src/features/XIT/PROD/MaterialRow.vue
@@ -14,10 +14,11 @@ interface Assignment {
   amount: number;
 }
 
-const { burn, material, assignments } = defineProps<{
+const { burn, material, assignments, siteId } = defineProps<{
   burn: MaterialBurn;
   material: PrunApi.Material;
   assignments: Assignment[];
+  siteId: string;
 }>();
 
 const emit = defineEmits<{
@@ -48,6 +49,7 @@ function openAdd(ev: Event) {
     maxAmount: burn.output,
     ticker: material.ticker,
     direction: 'export',
+    currentSiteId: siteId,
     onSave: (siteId: string, amount: number) => emit('add-assignment', siteId, amount),
   });
 }
@@ -57,6 +59,7 @@ function openImport(ev: Event) {
     maxAmount: Math.abs(sum.value),
     ticker: material.ticker,
     direction: 'import',
+    currentSiteId: siteId,
     onSave: (siteId: string, amount: number) => emit('import-assignment', siteId, amount),
   });
 }

--- a/src/features/XIT/PROD/PlanetSection.vue
+++ b/src/features/XIT/PROD/PlanetSection.vue
@@ -42,6 +42,7 @@ function toggle() {
     <MaterialList
       :burn="burn"
       :assignments="assignments"
+      :site-id="burn.storeId"
       @add-assignment="(t, s, a) => emit('add-assignment', burn.storeId, t, s, a)"
       @import-assignment="(t, s, a) => emit('import-assignment', s, t, burn.storeId, a)"
     />


### PR DESCRIPTION
## Summary
- pass current site id through material list and rows
- rework AddAssignmentOverlay to use a table for both import and export
- highlight the selected site and validate amount
- hide amount input until a site is chosen

## Testing
- `npm run lint` *(fails: fetch error)*
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493530c4ec83259bbb97f2472050a1