### PR TITLE
Fix import/export same-site bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 25.6.9.1558
+
+### Fixed
+
+- `XIT PROD`: Prevent selecting the same site for import or export assignments
+
 ## 25.6.9.1557
 
 ### Fixed

--- a/src/core/burn.ts
+++ b/src/core/burn.ts
@@ -24,6 +24,7 @@ export interface BurnValues {
 }
 
 export interface PlanetBurn {
+  siteId: string;
   storeId: string;
   planetName: string;
   naturalId: string;
@@ -49,6 +50,7 @@ const burnBySiteId = computed(() => {
         }
 
         return {
+          siteId: site.siteId,
           storeId: storage?.[0]?.id,
           planetName: getEntityNameFromAddress(site.address),
           naturalId: getEntityNaturalIdFromAddress(site.address),

--- a/src/features/XIT/PROD/PlanetSection.vue
+++ b/src/features/XIT/PROD/PlanetSection.vue
@@ -42,7 +42,7 @@ function toggle() {
     <MaterialList
       :burn="burn"
       :assignments="assignments"
-      :site-id="burn.storeId"
+      :site-id="burn.siteId"
       @add-assignment="(t, s, a) => emit('add-assignment', burn.storeId, t, s, a)"
       @import-assignment="(t, s, a) => emit('import-assignment', s, t, burn.storeId, a)"
     />


### PR DESCRIPTION
## Summary
- prevent selecting the current site when adding transfers
- expose `siteId` inside `PlanetBurn`
- document fix in changelog

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*
- `pnpm compile` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68493ab2645c832595986bf10b9f71e8