### PR TITLE
Fix amount rounding and disable assignment buttons

### DIFF
--- a/src/components/forms/NumberInput.vue
+++ b/src/components/forms/NumberInput.vue
@@ -7,7 +7,8 @@ const inputModel = computed({
   get: () => model.value,
   set: (value: string) => {
     if (value !== '') {
-      model.value = parseInt(value, 10);
+      const parsed = Math.ceil(parseFloat(value));
+      model.value = Number.isNaN(parsed) ? 0 : parsed;
       return;
     }
     if (optional) {
@@ -27,6 +28,7 @@ const inputModel = computed({
       :max="max"
       v-model="inputModel"
       type="number"
+      step="1"
       autocomplete="off"
       data-1p-ignore="true"
       data-lpignore="true" />

--- a/src/features/XIT/PROD/MaterialRow.vue
+++ b/src/features/XIT/PROD/MaterialRow.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { MaterialBurn } from '@src/core/burn';
+import { MaterialBurn, getPlanetBurn } from '@src/core/burn';
 import MaterialIcon from '@src/components/MaterialIcon.vue';
 import { fixed0 } from '@src/utils/format';
 import PrunButton from '@src/components/PrunButton.vue';
@@ -43,6 +43,28 @@ const sumClass = computed(() => ({
   [C.ColoredValue.positive]: sum.value > 0,
   [C.ColoredValue.negative]: sum.value < 0,
 }));
+
+const hasImportSites = computed(() =>
+  (sitesStore.all.value ?? [])
+    .filter(s => s.siteId !== siteId)
+    .some(site => {
+      const burn = getPlanetBurn(site.siteId);
+      const b = burn?.burn[material.ticker];
+      const net = b ? b.output - b.input - b.workforce : 0;
+      return net > 0;
+    }),
+);
+
+const hasExportSites = computed(() =>
+  (sitesStore.all.value ?? [])
+    .filter(s => s.siteId !== siteId)
+    .some(site => {
+      const burn = getPlanetBurn(site.siteId);
+      const b = burn?.burn[material.ticker];
+      const net = b ? b.output - b.input - b.workforce : 0;
+      return net < 0;
+    }),
+);
 
 function openAdd(ev: Event) {
   showTileOverlay(ev, AddAssignmentOverlay, {
@@ -90,8 +112,8 @@ function siteName(id: string) {
     <td :class="sumClass">{{ sum === 0 ? '' : fixed0(sum) }}</td>
     <td><BalanceBar :value="sum" /></td>
     <td>
-      <PrunButton dark inline @click.stop="openImport">IMPORT</PrunButton>
-      <PrunButton dark inline @click.stop="openAdd">EXPORT</PrunButton>
+      <PrunButton dark inline @click.stop="openImport" :disabled="!hasImportSites">IMPORT</PrunButton>
+      <PrunButton dark inline @click.stop="openAdd" :disabled="!hasExportSites">EXPORT</PrunButton>
     </td>
   </tr>
   <tr v-if="expanded" v-for="(a, i) in assignments" :key="i">


### PR DESCRIPTION
## Summary
- round all `NumberInput` values up to the next whole number
- disable import/export buttons when no applicable sites exist

## Testing
- `pnpm compile` *(fails: fetch failed)*
- `pnpm build` *(fails: fetch failed)*
- `pnpm lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68493caad8308325b5ba4b4148233bfa