### PR TITLE
Fix production assignment site store mapping

### DIFF
--- a/src/features/XIT/PROD/PROD.vue
+++ b/src/features/XIT/PROD/PROD.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import { getPlanetBurn } from '@src/core/burn';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { useXitParameters } from '@src/hooks/use-xit-parameters';
 import { isDefined, isEmpty } from 'ts-extras';
 import LoadingSpinner from '@src/components/LoadingSpinner.vue';
@@ -24,11 +25,13 @@ const sites = computed(() => {
 const planetBurn = computed(() => sites.value?.map(getPlanetBurn).filter(isDefined) ?? []);
 
 function onAddAssignment(from: string, ticker: string, to: string, amount: number) {
-  addAssignment(from, ticker, to, amount);
+  const toStore = storagesStore.getByAddressableId(to)?.find(s => s.type === 'STORE');
+  addAssignment(from, ticker, toStore?.id ?? to, amount);
 }
 
 function importAssignment(from: string, ticker: string, to: string, amount: number) {
-  addAssignment(from, ticker, to, amount);
+  const fromStore = storagesStore.getByAddressableId(from)?.find(s => s.type === 'STORE');
+  addAssignment(fromStore?.id ?? from, ticker, to, amount);
 }
 </script>
 


### PR DESCRIPTION
## Summary
- fix cross-site exports not appearing by converting site ids to store ids

## Testing
- `npm run lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*
- `npm run compile` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684941cd60188325a72b070a7f5722cd