### PR TITLE
Fix Import/Export deletion and show site names

### DIFF
--- a/src/features/XIT/PROD/MaterialList.vue
+++ b/src/features/XIT/PROD/MaterialList.vue
@@ -15,10 +15,11 @@ const emit = defineEmits<{
   (e: 'import-assignment', ticker: string, siteId: string, amount: number): void;
 }>();
 
-const { burn, assignments, siteId } = defineProps<{
+const { burn, assignments, siteId, storeId } = defineProps<{
   burn: PlanetBurn;
   assignments: Record<string, Assignment[]>;
   siteId: string;
+  storeId: string;
 }>();
 
 const materials = computed(() => Object.keys(burn.burn).map(materialsStore.getByTicker));
@@ -58,6 +59,7 @@ function onImport(ticker: string, siteId: string, amount: number) {
     :material="material!"
     :assignments="assignments[material!.ticker] ?? []"
     :site-id="siteId"
+    :store-id="storeId"
     @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)"
     @import-assignment="(s, amt) => onImport(material!.ticker, s, amt)" />
   <tr><th colspan="8">Consumed</th></tr>
@@ -68,6 +70,7 @@ function onImport(ticker: string, siteId: string, amount: number) {
     :material="material!"
     :assignments="assignments[material!.ticker] ?? []"
     :site-id="siteId"
+    :store-id="storeId"
     @add-assignment="(s, amt) => onAdd(material!.ticker, s, amt)"
     @import-assignment="(s, amt) => onImport(material!.ticker, s, amt)" />
 </template>

--- a/src/features/XIT/PROD/MaterialRow.vue
+++ b/src/features/XIT/PROD/MaterialRow.vue
@@ -8,6 +8,7 @@ import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
 import AddAssignmentOverlay from './AddAssignmentOverlay.vue';
 import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import { removeAssignment as removeStoreAssignment } from '@src/store/production-assignments';
 
 interface Assignment {
@@ -15,11 +16,12 @@ interface Assignment {
   amount: number;
 }
 
-const { burn, material, assignments, siteId } = defineProps<{
+const { burn, material, assignments, siteId, storeId } = defineProps<{
   burn: MaterialBurn;
   material: PrunApi.Material;
   assignments: Assignment[];
   siteId: string;
+  storeId: string;
 }>();
 
 const emit = defineEmits<{
@@ -88,11 +90,13 @@ function openImport(ev: Event) {
 }
 
 function removeAssignment(index: number) {
-  removeStoreAssignment(siteId, material.ticker, index);
+  removeStoreAssignment(storeId, material.ticker, index);
 }
 
 function siteName(id: string) {
-  const site = sitesStore.getById(id);
+  const site =
+    sitesStore.getById(id) ??
+    sitesStore.getById(storagesStore.getById(id)?.addressableId);
   return site ? getEntityNameFromAddress(site.address) : id;
 }
 </script>

--- a/src/features/XIT/PROD/PlanetSection.vue
+++ b/src/features/XIT/PROD/PlanetSection.vue
@@ -43,6 +43,7 @@ function toggle() {
       :burn="burn"
       :assignments="assignments"
       :site-id="burn.siteId"
+      :store-id="burn.storeId"
       @add-assignment="(t, s, a) => emit('add-assignment', burn.storeId, t, s, a)"
       @import-assignment="(t, s, a) => emit('import-assignment', s, t, burn.storeId, a)"
     />


### PR DESCRIPTION
## Summary
- fix removing import/export assignments by using storeId
- show planet site names instead of storeIds in Import/Export rows

## Testing
- `npm run compile` *(fails: Cannot find type definition file for 'node')*
- `npm run lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68494372674c8325a32114aeae7aa54a