### PR TITLE
Add filter for consumption materials in PROD

### DIFF
--- a/src/features/XIT/PROD/MaterialList.vue
+++ b/src/features/XIT/PROD/MaterialList.vue
@@ -4,6 +4,7 @@ import { PlanetBurn } from '@src/core/burn';
 import MaterialRow from './MaterialRow.vue';
 import { sortMaterials } from '@src/core/sort-materials';
 import { isDefined } from 'ts-extras';
+import { useTileState } from './tile-state';
 
 interface Assignment {
   siteId: string;
@@ -22,13 +23,16 @@ const { burn, assignments, siteId, storeId } = defineProps<{
   storeId: string;
 }>();
 
+const showConsumption = useTileState('showConsumption');
+
 const materials = computed(() => Object.keys(burn.burn).map(materialsStore.getByTicker));
 const sorted = computed(() => sortMaterials(materials.value.filter(isDefined)));
 
 function visible(material: PrunApi.Material | undefined) {
   if (!material) return false;
   const b = burn.burn[material.ticker];
-  return b.output !== 0 || b.input !== 0;
+  const isConsumption = b.output === 0 && b.input === 0;
+  return showConsumption.value || !isConsumption;
 }
 
 const produced = computed(() =>

--- a/src/features/XIT/PROD/PROD.vue
+++ b/src/features/XIT/PROD/PROD.vue
@@ -7,6 +7,8 @@ import { useXitParameters } from '@src/hooks/use-xit-parameters';
 import { isDefined, isEmpty } from 'ts-extras';
 import LoadingSpinner from '@src/components/LoadingSpinner.vue';
 import PlanetSection from './PlanetSection.vue';
+import FilterButton from '@src/features/XIT/BURN/FilterButton.vue';
+import { useTileState } from './tile-state';
 import {
   addAssignment,
   getAssignments,
@@ -24,6 +26,8 @@ const sites = computed(() => {
 
 const planetBurn = computed(() => sites.value?.map(getPlanetBurn).filter(isDefined) ?? []);
 
+const showConsumption = useTileState('showConsumption');
+
 function onAddAssignment(from: string, ticker: string, to: string, amount: number) {
   const toStore = storagesStore.getByAddressableId(to)?.find(s => s.type === 'STORE');
   addAssignment(from, ticker, toStore?.id ?? to, amount);
@@ -38,6 +42,9 @@ function importAssignment(from: string, ticker: string, to: string, amount: numb
 <template>
   <LoadingSpinner v-if="sites === undefined" />
   <template v-else>
+    <div :class="C.ComExOrdersPanel.filter">
+      <FilterButton v-model="showConsumption">CONSUMPTION</FilterButton>
+    </div>
     <table>
       <thead>
         <tr>

--- a/src/features/XIT/PROD/tile-state.ts
+++ b/src/features/XIT/PROD/tile-state.ts
@@ -1,0 +1,6 @@
+import { createTileStateHook } from '@src/store/user-data-tiles';
+
+export const useTileState = createTileStateHook({
+  showConsumption: false,
+});
+


### PR DESCRIPTION
## Summary
- add tile state for PROD
- filter consumption materials using tile state
- add FilterButton above PROD table

## Testing
- `npm run lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*
- `npm run compile` *(fails: cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68494fc341288325bd056e956564ce13