### PR TITLE
Add station options and save PROD panel state

### DIFF
--- a/src/features/XIT/PROD/AddAssignmentOverlay.vue
+++ b/src/features/XIT/PROD/AddAssignmentOverlay.vue
@@ -30,6 +30,7 @@ interface SiteOption {
   value: string;
   deficit: number;
   surplus: number;
+  station?: boolean;
 }
 
 const sites = computed<SiteOption[]>(() => {
@@ -59,17 +60,18 @@ const sites = computed<SiteOption[]>(() => {
         value: w.storeId,
         deficit: 0,
         surplus: 0,
+        station: true,
       })) ?? [];
 
   return [...baseSites, ...stationSites];
 });
 
 const importOptions = computed(() =>
-  sites.value.filter(s => s.surplus > 0),
+  sites.value.filter(s => s.surplus > 0 || s.station),
 );
 
 const exportOptions = computed(() =>
-  sites.value.filter(s => s.deficit > 0),
+  sites.value.filter(s => s.deficit > 0 || s.station),
 );
 
 const selectedSite = computed(() =>

--- a/src/features/XIT/PROD/PlanetSection.vue
+++ b/src/features/XIT/PROD/PlanetSection.vue
@@ -2,6 +2,7 @@
 import { PlanetBurn } from '@src/core/burn';
 import PlanetHeader from '@src/features/XIT/BURN/PlanetHeader.vue';
 import MaterialList from './MaterialList.vue';
+import { useTileState } from './tile-state';
 
 const emit = defineEmits<{
   (
@@ -26,11 +27,17 @@ const { burn, assignments, canMinimize } = defineProps<{
   canMinimize?: boolean;
 }>();
 
-const expanded = ref(true);
+const expand = useTileState('expand');
+const naturalId = computed(() => burn.naturalId);
+const expanded = computed(() => expand.value.includes(naturalId.value));
 
 function toggle() {
   if (!canMinimize) return;
-  expanded.value = !expanded.value;
+  if (expanded.value) {
+    expand.value = expand.value.filter(id => id !== naturalId.value);
+  } else {
+    expand.value = [...expand.value, naturalId.value];
+  }
 }
 </script>
 

--- a/src/features/XIT/PROD/tile-state.ts
+++ b/src/features/XIT/PROD/tile-state.ts
@@ -3,5 +3,6 @@ import { createTileStateHook } from '@src/store/user-data-tiles';
 export const useTileState = createTileStateHook({
   showConsumption: false,
   showStations: true,
+  expand: [] as string[],
 });
 


### PR DESCRIPTION
## Summary
- include stations when selecting import/export destinations
- remember open/closed PROD sections using tile state

## Testing
- `npm run lint` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6849539b50a8832586985a64302e3f50