### PR TITLE
Add import/export mass+volume to PROD header

### DIFF
--- a/src/features/XIT/PROD/PlanetHeader.vue
+++ b/src/features/XIT/PROD/PlanetHeader.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { PlanetBurn } from '@src/core/burn';
 import { countDays } from '@src/features/XIT/BURN/utils';
+import {
+  getExportMassTotal,
+  getExportVolumeTotal,
+  getImportMassTotal,
+  getImportVolumeTotal,
+} from '@src/store/production-assignments';
+import { fixed2 } from '@src/utils/format';
 
 const { burn } = defineProps<{
   burn: PlanetBurn;
@@ -9,8 +16,12 @@ const { burn } = defineProps<{
   onClick: () => void;
 }>();
 
-
 const days = computed(() => countDays(burn.burn));
+
+const importMass = computed(() => getImportMassTotal(burn.storeId));
+const exportMass = computed(() => getExportMassTotal(burn.storeId));
+const importVolume = computed(() => getImportVolumeTotal(burn.storeId));
+const exportVolume = computed(() => getExportVolumeTotal(burn.storeId));
 </script>
 
 <template>
@@ -19,7 +30,16 @@ const days = computed(() => countDays(burn.burn));
       <span v-if="hasMinimize" :class="$style.minimize">
         {{ minimized ? '+' : '-' }}
       </span>
-      <span>{{ burn.planetName }} {{ burn.planetName != burn.naturalId ? `(${burn.naturalId})` : '' }}</span>
+      <span
+        >{{ burn.planetName }}
+        {{ burn.planetName != burn.naturalId ? `(${burn.naturalId})` : '' }}</span
+      >
+    </td>
+  </tr>
+  <tr :class="$style.row">
+    <td colspan="8" :class="$style.subCell">
+      Import: {{ fixed2(importMass) }}t / {{ fixed2(importVolume) }}m³ | Export:
+      {{ fixed2(exportMass) }}t / {{ fixed2(exportVolume) }}m³
     </td>
   </tr>
 </template>
@@ -47,5 +67,10 @@ const days = computed(() => countDays(burn.burn));
   flex-direction: row;
   flex-wrap: wrap;
   column-gap: 0.25rem;
+}
+
+.subCell {
+  font-size: 11px;
+  text-align: center;
 }
 </style>

--- a/src/store/production-assignments.ts
+++ b/src/store/production-assignments.ts
@@ -11,7 +11,6 @@ type SiteAssignments = Record<string, ProductionAssignment[]>;
 export type ProductionAssignments = Record<string, SiteAssignments>;
 
 function ensureSite(id: string): SiteAssignments {
-
   return (userData.productionAssignments[id] ??= reactive({}));
 }
 
@@ -40,8 +39,7 @@ export function removeAssignment(siteId: string, ticker: string, index: number) 
   if (destIndex !== -1) destArr.splice(destIndex, 1);
 }
 
-export function clearAllAssignments ()
-{
+export function clearAllAssignments() {
   userData.productionAssignments = reactive({});
 }
 
@@ -91,6 +89,66 @@ export function getVolume(from: string, to: string, ticker?: string): number {
     eachExport(from, to, t, (amount, material) => {
       total += (material?.volume ?? 0) * amount;
     });
+  }
+  return total;
+}
+
+export function getExportMassTotal(siteId: string): number {
+  let total = 0;
+  const site = getAssignments(siteId);
+  for (const [ticker, arr] of Object.entries(site)) {
+    const material = materialsStore.getByTicker(ticker);
+    const weight = material?.weight ?? 0;
+    for (const a of arr) {
+      if (a.amount < 0) {
+        total += weight * -a.amount;
+      }
+    }
+  }
+  return total;
+}
+
+export function getImportMassTotal(siteId: string): number {
+  let total = 0;
+  const site = getAssignments(siteId);
+  for (const [ticker, arr] of Object.entries(site)) {
+    const material = materialsStore.getByTicker(ticker);
+    const weight = material?.weight ?? 0;
+    for (const a of arr) {
+      if (a.amount > 0) {
+        total += weight * a.amount;
+      }
+    }
+  }
+  return total;
+}
+
+export function getExportVolumeTotal(siteId: string): number {
+  let total = 0;
+  const site = getAssignments(siteId);
+  for (const [ticker, arr] of Object.entries(site)) {
+    const material = materialsStore.getByTicker(ticker);
+    const volume = material?.volume ?? 0;
+    for (const a of arr) {
+      if (a.amount < 0) {
+        total += volume * -a.amount;
+      }
+    }
+  }
+  return total;
+}
+
+export function getImportVolumeTotal(siteId: string): number {
+  let total = 0;
+  const site = getAssignments(siteId);
+  for (const [ticker, arr] of Object.entries(site)) {
+    const material = materialsStore.getByTicker(ticker);
+    const volume = material?.volume ?? 0;
+    for (const a of arr) {
+      if (a.amount > 0) {
+        total += volume * a.amount;
+      }
+    }
   }
   return total;
 }


### PR DESCRIPTION
## Summary
- show total import/export mass & volume in PROD PlanetHeader
- add helpers to compute site totals for mass and volume

## Testing
- `npm run lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*
- `npm run compile` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68497cc8ec288325a1115e66f193257d