### PR TITLE
Add PRODVIEW XIT command

### DIFF
--- a/src/features/XIT/PRODVIEW/PRODVIEW.ts
+++ b/src/features/XIT/PRODVIEW/PRODVIEW.ts
@@ -1,0 +1,8 @@
+import PRODVIEW from '@src/features/XIT/PRODVIEW/PRODVIEW.vue';
+
+xit.add({
+  command: 'PRODVIEW',
+  name: 'PRODUCTION GRAPH',
+  description: 'Visualizes production assignments as a graph.',
+  component: () => PRODVIEW,
+});

--- a/src/features/XIT/PRODVIEW/PRODVIEW.vue
+++ b/src/features/XIT/PRODVIEW/PRODVIEW.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import Cytoscape from 'vue-cytoscape';
+import { userData } from '@src/store/user-data';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+
+function getName(id: string): string {
+  const site =
+    sitesStore.getById(id) ?? sitesStore.getById(storagesStore.getById(id)?.addressableId);
+  if (site) {
+    return getEntityNameFromAddress(site.address) ?? id;
+  }
+  const warehouse =
+    warehousesStore.getById(id) ?? warehousesStore.getById(storagesStore.getById(id)?.addressableId);
+  if (warehouse) {
+    return getEntityNameFromAddress(warehouse.address) ?? id;
+  }
+  const store = storagesStore.getById(id);
+  return store?.name ?? id;
+}
+
+const elements = computed(() => {
+  const nodes: Record<string, any> = {};
+  const edges: any[] = [];
+  const assignments = userData.productionAssignments;
+  for (const [from, mats] of Object.entries(assignments)) {
+    nodes[from] = { data: { id: from, label: getName(from) } };
+    for (const [ticker, arr] of Object.entries(mats)) {
+      for (const a of arr as any[]) {
+        const to = (a as any).siteId;
+        const amount = a.amount as number;
+        nodes[to] = { data: { id: to, label: getName(to) } };
+        edges.push({
+          data: {
+            id: `${from}-${to}-${ticker}-${amount}`,
+            source: from,
+            target: to,
+            label: `${ticker} ${amount > 0 ? '+' : ''}${amount}`,
+          },
+        });
+      }
+    }
+  }
+  return Object.values(nodes).concat(edges);
+});
+
+const layout = { name: 'cose' };
+</script>
+
+<template>
+  <Cytoscape :elements="elements" :layout="layout" style="width: 100%; height: 100%;" />
+</template>

--- a/src/features/XIT/index.ts
+++ b/src/features/XIT/index.ts
@@ -1,5 +1,6 @@
 import './ACT/ACT';
 import './PROD/PROD';
+import './PRODVIEW/PRODVIEW';
 import './BURN/BURN';
 import './CALC';
 import './CHAT';


### PR DESCRIPTION
## Summary
- visualize production routes with vue-cytoscape
- register PRODVIEW XIT command

## Testing
- `npm run lint` *(fails: Error when performing the request ...)*

------
https://chatgpt.com/codex/tasks/task_e_6849824de2a88325b9723ed703adf24b