### PR TITLE
Add test flight calculation utility

### DIFF
--- a/src/infrastructure/prun-api/data/api-messages.ts
+++ b/src/infrastructure/prun-api/data/api-messages.ts
@@ -13,6 +13,12 @@ const registry = new Map<string, MessageHandler[]>();
 
 export function onAnyApiMessage(handler: MessageHandler) {
   any.push(handler);
+  return () => {
+    const index = any.indexOf(handler);
+    if (index >= 0) {
+      any.splice(index, 1);
+    }
+  };
 }
 
 export function onApiMessage(handlers: MessageHandlers) {

--- a/src/infrastructure/prun-api/ship-flight.ts
+++ b/src/infrastructure/prun-api/ship-flight.ts
@@ -1,0 +1,43 @@
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
+import { context } from '@src/infrastructure/prun-api/data/screens';
+import { flightPlansStore } from '@src/infrastructure/prun-api/data/flight-plans';
+import { watchUntil } from '@src/utils/watch';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface TestFlightParams {
+  blueprintId: string;
+  origin: string;
+  destination: string;
+  landing: boolean;
+  waypoints: string[];
+  fuelUsageFactor: number;
+  reactorUsageFactor: number;
+  payload: number;
+  condition: number;
+  stlFuel: number;
+  ftlFuel: number;
+}
+
+export async function calculateTestFlight(
+  params: TestFlightParams,
+): Promise<PrunApi.FlightPlan> {
+  const missionId = uuidv4();
+  const actionId = uuidv4();
+  const message = {
+    messageType: 'SHIP_FLIGHT_CALCULATE_TEST_FLIGHT',
+    payload: {
+      ...params,
+      missionId,
+      actionId,
+    },
+    contextId: context.value,
+  };
+
+  if (!dispatchClientPrunMessage(message)) {
+    throw new Error('Unable to dispatch test flight message');
+  }
+
+  await watchUntil(() => flightPlansStore.getById(missionId) !== undefined);
+
+  return flightPlansStore.getById(missionId)!;
+}


### PR DESCRIPTION
## Summary
- add a removable listener capability in `onAnyApiMessage`
- introduce `calculateTestFlight` helper to send SHIP_FLIGHT_CALCULATE_TEST_FLIGHT events and await the mission plan

## Testing
- `npm run compile` *(fails: Cannot find type definition file for 'node' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684aa35d6a148325b0e78b8b432bcca7