### PR TITLE
Add flight route planner scaffolding

### DIFF
--- a/src/core/flightroute-controller.ts
+++ b/src/core/flightroute-controller.ts
@@ -1,0 +1,50 @@
+import { v4 as uuidv4 } from 'uuid';
+import { addActive, finishRoute, getActiveById, removeActive } from '@src/store/flightroutes';
+
+export function dummy(action: string, ...args: unknown[]) {
+  console.log(`[FRP] ${action}`, ...args);
+}
+
+export class FlightplanController {
+  finished: UserData.ActiveFlightroute[] = [];
+  active: UserData.ActiveFlightroute[] = [];
+
+  constructor() {
+    console.log('FlightplanController initialized');
+  }
+
+  startPlan(shipId: string, plan: UserData.FlightroutePlan) {
+    const route: UserData.ActiveFlightroute = {
+      id: uuidv4(),
+      shipId,
+      plan,
+      state: 0,
+      history: {},
+    };
+    addActive(route);
+    this.active.push(route);
+    dummy('start plan', shipId, plan.id);
+    return route.id;
+  }
+
+  cancelPlan(id: string) {
+    const route = getActiveById(id);
+    if (!route) return;
+    removeActive(id);
+    this.active = this.active.filter(r => r.id !== id);
+    dummy('cancel plan', id);
+  }
+
+  completeCurrentAction(id: string) {
+    const route = getActiveById(id);
+    if (!route) return;
+    route.history[route.state] = Date.now();
+    route.state++;
+    if (route.state >= route.plan.actions.length) {
+      finishRoute(id);
+      this.active = this.active.filter(r => r.id !== id);
+      this.finished.push(route);
+    }
+    dummy('complete action', id, route.state);
+  }
+}

--- a/src/features/XIT/FRP/FRP.ts
+++ b/src/features/XIT/FRP/FRP.ts
@@ -1,0 +1,9 @@
+import FRP from '@src/features/XIT/FRP/FRP.vue';
+
+xit.add({
+  command: ['FRP'],
+  name: 'FLIGHT ROUTE PLANNER',
+  description: 'Define and monitor flight routes.',
+  optionalParameters: 'Route Identifier',
+  component: () => FRP,
+});

--- a/src/features/XIT/FRP/FRP.vue
+++ b/src/features/XIT/FRP/FRP.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
+import { userData } from '@src/store/user-data';
+
+const parameters = useXitParameters();
+const routeId = parameters[0];
+const route = computed(() => {
+  const byActive = userData.flightRoutes.active.find(r => r.id.startsWith(routeId));
+  if (byActive) return byActive;
+  return userData.flightRoutes.finished.find(r => r.id.startsWith(routeId));
+});
+</script>
+
+<template>
+  <div>
+    <table v-if="route">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Destination</th>
+          <th>Transfers</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="(action, index) in route.plan.actions"
+          :key="index"
+          :class="{ current: index === route.state, done: index < route.state }"
+        >
+          <td>{{ index + 1 }}</td>
+          <td>{{ action.destination }}</td>
+          <td>
+            <div v-if="action.dumpCargo">Dump Cargo</div>
+            <div v-for="t in action.transfers" :key="t.ticker + t.direction">
+              {{ t.direction }} {{ t.amount ?? 'ALL' }} {{ t.ticker }}
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div v-else>No route found.</div>
+  </div>
+</template>
+
+<style module>
+.current {
+  background: rgba(0, 128, 0, 0.2);
+}
+.done {
+  opacity: 0.5;
+}
+</style>

--- a/src/features/XIT/index.ts
+++ b/src/features/XIT/index.ts
@@ -26,4 +26,5 @@ import './START';
 import './TODO/TODO';
 import './WEB/WEB';
 import './CXORDER/CXORDER';
+import './FRP/FRP';
 import './xit-commands';

--- a/src/store/flightroutes.ts
+++ b/src/store/flightroutes.ts
@@ -1,0 +1,26 @@
+import { userData } from '@src/store/user-data';
+
+export function addActive(route: UserData.ActiveFlightroute) {
+  userData.flightRoutes.active.push(route);
+}
+
+export function finishRoute(id: string) {
+  const idx = userData.flightRoutes.active.findIndex(r => r.id === id);
+  if (idx !== -1) {
+    const [route] = userData.flightRoutes.active.splice(idx, 1);
+    userData.flightRoutes.finished.push(route);
+  }
+}
+
+export function removeActive(id: string) {
+  const idx = userData.flightRoutes.active.findIndex(r => r.id === id);
+  if (idx !== -1) userData.flightRoutes.active.splice(idx, 1);
+}
+
+export function getActiveByShipId(shipId: string) {
+  return userData.flightRoutes.active.find(r => r.shipId === shipId);
+}
+
+export function getActiveById(id: string) {
+  return userData.flightRoutes.active.find(r => r.id === id);
+}

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -64,6 +64,10 @@ export const initialUserData = deepFreeze({
   },
   commandLists: [] as UserData.CommandList[],
   productionAssignments: {} as Record<string, Record<string, UserData.ProductionAssignment[]>>,
+  flightRoutes: {
+    active: [],
+    finished: [],
+  } as UserData.FlightrouteStore,
   favorites: {
     ticker: []
   } as UserData.Favorites

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -120,4 +120,36 @@ declare namespace UserData {
   }
 
   type ProductionAssignments = Record<string, Record<string, ProductionAssignment[]>>;
+
+  type Direction = 'IN' | 'OUT';
+
+  interface Transfer {
+    ticker: string;
+    amount?: number;
+    direction: Direction;
+  }
+
+  interface FlightrouteAction {
+    destination: string;
+    transfers?: Transfer[];
+    dumpCargo?: boolean;
+  }
+
+  interface FlightroutePlan {
+    id: string;
+    actions: FlightrouteAction[];
+  }
+
+  interface ActiveFlightroute {
+    id: string;
+    shipId: string;
+    plan: FlightroutePlan;
+    state: number;
+    history: Record<number, number>;
+  }
+
+  interface FlightrouteStore {
+    active: ActiveFlightroute[];
+    finished: ActiveFlightroute[];
+  }
 }


### PR DESCRIPTION
## Summary
- add new Fly Route Planner buffer and register command
- store active and finished flight routes in user data
- define flight route types and controller
- basic Vue UI to display a flight route

## Testing
- `npm run compile` *(fails: Cannot find type definition file for 'node')*
- `npm run lint` *(fails: network access for pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_684beb56ce388325b43997394878b9c8