### PR TITLE
Add flightroute plan editor

### DIFF
--- a/src/features/XIT/FRP/EditFlightrouteAction.vue
+++ b/src/features/XIT/FRP/EditFlightrouteAction.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import NumberInput from '@src/components/forms/NumberInput.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import { showTileOverlay, showConfirmationOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import removeArrayElement from '@src/utils/remove-array-element';
+import EditFlightrouteTransfer from '@src/features/XIT/FRP/EditFlightrouteTransfer.vue';
+
+const { action, add, onSave } = defineProps<{ action: UserData.FlightrouteAction; add?: boolean; onSave?: () => void }>();
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+function addTransfer(ev: Event) {
+  const transfer: UserData.Transfer = { ticker: '', direction: 'IN' };
+  showTileOverlay(ev, EditFlightrouteTransfer, {
+    transfer,
+    add: true,
+    onSave: () => {
+      if (!action.transfers) action.transfers = [];
+      action.transfers.push(transfer);
+    },
+  });
+}
+
+function editTransfer(ev: Event, transfer: UserData.Transfer) {
+  showTileOverlay(ev, EditFlightrouteTransfer, { transfer });
+}
+
+function deleteTransfer(ev: Event, transfer: UserData.Transfer) {
+  showConfirmationOverlay(ev, () => removeArrayElement(action.transfers!, transfer), {
+    message: 'Delete this transfer?',
+    confirmLabel: 'DELETE',
+  });
+}
+
+function save() {
+  onSave?.();
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>{{ add ? 'Add' : 'Edit' }} Action</SectionHeader>
+    <form>
+      <Active label="Destination">
+        <TextInput v-model="action.destination" />
+      </Active>
+      <Active label="Dump Cargo">
+        <input type="checkbox" v-model="action.dumpCargo" />
+      </Active>
+      <SectionHeader>Transfers</SectionHeader>
+      <table>
+        <thead>
+          <tr>
+            <th>Ticker</th>
+            <th>Amount</th>
+            <th>Direction</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody v-if="!action.transfers || action.transfers.length === 0">
+          <tr>
+            <td colspan="4" :class="$style.empty">No transfers.</td>
+          </tr>
+        </tbody>
+        <tbody v-else>
+          <tr v-for="(t, i) in action.transfers" :key="i">
+            <td>{{ t.ticker }}</td>
+            <td>{{ t.amount ?? 'ALL' }}</td>
+            <td>{{ t.direction }}</td>
+            <td>
+              <PrunButton dark inline @click="editTransfer($event, t)">edit</PrunButton>
+              <PrunButton danger inline @click="deleteTransfer($event, t)">delete</PrunButton>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <Commands>
+        <PrunButton primary @click="addTransfer">ADD TRANSFER</PrunButton>
+      </Commands>
+      <Commands>
+        <PrunButton primary @click="save">{{ add ? 'ADD' : 'DONE' }}</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>
+
+<style module>
+.empty {
+  text-align: center;
+}
+</style>

--- a/src/features/XIT/FRP/EditFlightroutePlan.vue
+++ b/src/features/XIT/FRP/EditFlightroutePlan.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import { showTileOverlay, showConfirmationOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import removeArrayElement from '@src/utils/remove-array-element';
+import EditFlightrouteAction from '@src/features/XIT/FRP/EditFlightrouteAction.vue';
+
+const { plan, add, onSave } = defineProps<{ plan: UserData.FlightroutePlan; add?: boolean; onSave?: () => void }>();
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+function addAction(ev: Event) {
+  const action: UserData.FlightrouteAction = { destination: '', transfers: [] };
+  showTileOverlay(ev, EditFlightrouteAction, {
+    action,
+    add: true,
+    onSave: () => plan.actions.push(action),
+  });
+}
+
+function editAction(ev: Event, action: UserData.FlightrouteAction) {
+  showTileOverlay(ev, EditFlightrouteAction, { action });
+}
+
+function deleteAction(ev: Event, action: UserData.FlightrouteAction) {
+  showConfirmationOverlay(ev, () => removeArrayElement(plan.actions, action), {
+    message: 'Delete this action?',
+    confirmLabel: 'DELETE',
+  });
+}
+
+function save() {
+  onSave?.();
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>{{ add ? 'New' : 'Edit' }} Flight Plan</SectionHeader>
+    <form>
+      <table>
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Destination</th>
+            <th>Transfers</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody v-if="plan.actions.length === 0">
+          <tr>
+            <td colspan="4" :class="$style.empty">No actions yet.</td>
+          </tr>
+        </tbody>
+        <tbody v-else>
+          <tr v-for="(action, i) in plan.actions" :key="i">
+            <td>{{ i + 1 }}</td>
+            <td>{{ action.destination }}</td>
+            <td>
+              <div v-if="action.dumpCargo">Dump Cargo</div>
+              <div v-for="t in action.transfers" :key="t.ticker + t.direction">
+                {{ t.direction }} {{ t.amount ?? 'ALL' }} {{ t.ticker }}
+              </div>
+            </td>
+            <td>
+              <PrunButton dark inline @click="editAction($event, action)">edit</PrunButton>
+              <PrunButton danger inline @click="deleteAction($event, action)">delete</PrunButton>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <Commands>
+        <PrunButton primary @click="addAction">ADD ACTION</PrunButton>
+      </Commands>
+      <Commands>
+        <PrunButton primary @click="save">{{ add ? 'ADD' : 'DONE' }}</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>
+
+<style module>
+.empty {
+  text-align: center;
+}
+</style>

--- a/src/features/XIT/FRP/EditFlightrouteTransfer.vue
+++ b/src/features/XIT/FRP/EditFlightrouteTransfer.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import NumberInput from '@src/components/forms/NumberInput.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+
+const { transfer, add, onSave } = defineProps<{ transfer: UserData.Transfer; add?: boolean; onSave?: () => void }>();
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const directions: UserData.Direction[] = ['IN', 'OUT'];
+
+function save() {
+  onSave?.();
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>{{ add ? 'Add' : 'Edit' }} Transfer</SectionHeader>
+    <form>
+      <Active label="Ticker">
+        <TextInput v-model="transfer.ticker" />
+      </Active>
+      <Active label="Amount">
+        <NumberInput v-model="transfer.amount" />
+      </Active>
+      <Active label="Direction">
+        <SelectInput v-model="transfer.direction" :options="directions" />
+      </Active>
+      <Commands>
+        <PrunButton primary @click="save">{{ add ? 'ADD' : 'DONE' }}</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>

--- a/src/features/XIT/FRP/FRP.vue
+++ b/src/features/XIT/FRP/FRP.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { useXitParameters } from '@src/hooks/use-xit-parameters';
 import { userData } from '@src/store/user-data';
+import { isEmpty } from 'ts-extras';
+import FlightroutePlans from '@src/features/XIT/FRP/FlightroutePlans.vue';
 
 const parameters = useXitParameters();
 const routeId = parameters[0];
@@ -9,11 +11,13 @@ const route = computed(() => {
   if (byActive) return byActive;
   return userData.flightRoutes.finished.find(r => r.id.startsWith(routeId));
 });
+const plan = computed(() => userData.flightRoutes.plans.find(p => p.id.startsWith(routeId)));
 </script>
 
 <template>
   <div>
-    <table v-if="route">
+    <FlightroutePlans v-if="isEmpty(parameters)" />
+    <table v-else-if="route">
       <thead>
         <tr>
           <th>#</th>
@@ -27,6 +31,27 @@ const route = computed(() => {
           :key="index"
           :class="{ current: index === route.state, done: index < route.state }"
         >
+          <td>{{ index + 1 }}</td>
+          <td>{{ action.destination }}</td>
+          <td>
+            <div v-if="action.dumpCargo">Dump Cargo</div>
+            <div v-for="t in action.transfers" :key="t.ticker + t.direction">
+              {{ t.direction }} {{ t.amount ?? 'ALL' }} {{ t.ticker }}
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table v-else-if="plan">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Destination</th>
+          <th>Transfers</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(action, index) in plan.actions" :key="index">
           <td>{{ index + 1 }}</td>
           <td>{{ action.destination }}</td>
           <td>

--- a/src/features/XIT/FRP/FlightroutePlans.vue
+++ b/src/features/XIT/FRP/FlightroutePlans.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import ActionBar from '@src/components/ActionBar.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import { showTileOverlay, showConfirmationOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import { createId } from '@src/store/create-id';
+import { userData } from '@src/store/user-data';
+import { vDraggable } from 'vue-draggable-plus';
+import grip from '@src/utils/grip.module.css';
+import fa from '@src/utils/font-awesome.module.css';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import PrunLink from '@src/components/PrunLink.vue';
+import EditFlightroutePlan from '@src/features/XIT/FRP/EditFlightroutePlan.vue';
+
+function createNew(ev: Event) {
+  const plan: UserData.FlightroutePlan = { id: createId(), actions: [] };
+  showTileOverlay(ev, EditFlightroutePlan, {
+    plan,
+    add: true,
+    onSave: () => {
+      userData.flightRoutes.plans.push(plan);
+      showBuffer(`XIT FRP ${plan.id.substring(0, 8)}`);
+    },
+  });
+}
+
+function editPlan(ev: Event, plan: UserData.FlightroutePlan) {
+  showTileOverlay(ev, EditFlightroutePlan, { plan });
+}
+
+function confirmDelete(ev: Event, plan: UserData.FlightroutePlan) {
+  showConfirmationOverlay(ev, () => {
+    userData.flightRoutes.plans = userData.flightRoutes.plans.filter(p => p !== plan);
+  }, { message: 'Delete this plan?' });
+}
+
+const dragging = ref(false);
+
+const draggableOptions = {
+  animation: 150,
+  handle: `.${grip.grip}`,
+  onStart: () => (dragging.value = true),
+  onEnd: () => (dragging.value = false),
+};
+</script>
+
+<template>
+  <ActionBar>
+    <PrunButton primary @click="createNew">CREATE NEW</PrunButton>
+  </ActionBar>
+  <table>
+    <thead>
+      <tr>
+        <th>Id</th>
+        <th>Actions</th>
+        <th />
+      </tr>
+    </thead>
+    <tbody
+      v-draggable="[userData.flightRoutes.plans, draggableOptions]"
+      :class="dragging ? $style.dragging : null">
+      <tr v-for="plan in userData.flightRoutes.plans" :key="plan.id">
+        <td>
+          <span :class="[grip.grip, fa.solid, $style.grip]">{{ '\uf58e' }}</span>
+          <PrunLink inline :command="`XIT FRP ${plan.id.substring(0,8)}`">
+            {{ plan.id.substring(0, 8) }}
+          </PrunLink>
+        </td>
+        <td>{{ plan.actions.length }}</td>
+        <td>
+          <PrunButton dark inline @click="editPlan($event, plan)">edit</PrunButton>
+          <PrunButton danger inline @click="confirmDelete($event, plan)">delete</PrunButton>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<style module>
+.grip {
+  cursor: move;
+  transition: opacity 0.2s ease-in-out;
+  opacity: 0;
+  margin-right: 5px;
+}
+
+tr:hover .grip {
+  opacity: 1;
+}
+
+.dragging td .grip {
+  opacity: 0;
+}
+</style>

--- a/src/store/flightroutes.ts
+++ b/src/store/flightroutes.ts
@@ -4,6 +4,18 @@ export function addActive(route: UserData.ActiveFlightroute) {
   userData.flightRoutes.active.push(route);
 }
 
+export function addPlan(plan: UserData.FlightroutePlan) {
+  userData.flightRoutes.plans.push(plan);
+}
+
+export function removePlan(id: string) {
+  userData.flightRoutes.plans = userData.flightRoutes.plans.filter(p => p.id !== id);
+}
+
+export function getPlan(id: string) {
+  return userData.flightRoutes.plans.find(p => p.id === id);
+}
+
 export function finishRoute(id: string) {
   const idx = userData.flightRoutes.active.findIndex(r => r.id === id);
   if (idx !== -1) {

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -67,6 +67,7 @@ export const initialUserData = deepFreeze({
   flightRoutes: {
     active: [],
     finished: [],
+    plans: [],
   } as UserData.FlightrouteStore,
   favorites: {
     ticker: []

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -151,5 +151,6 @@ declare namespace UserData {
   interface FlightrouteStore {
     active: ActiveFlightroute[];
     finished: ActiveFlightroute[];
+    plans: FlightroutePlan[];
   }
 }


### PR DESCRIPTION
## Summary
- keep flightplan definitions in `userData`
- expose store helpers for manipulating plans
- show list of flight plans when opening `XIT FRP`
- dialogs to create and edit plans, actions and transfers

## Testing
- `npm run compile` *(fails: Cannot find type definition file for 'node')*
- `npm run lint` *(fails: network access needed for pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_684bf06f66188325837e76c226141692