### PR TITLE
Implement FRP plan names and action improvements

### DIFF
--- a/src/features/XIT/FRP/EditFlightrouteAction.vue
+++ b/src/features/XIT/FRP/EditFlightrouteAction.vue
@@ -3,15 +3,31 @@ import SectionHeader from '@src/components/SectionHeader.vue';
 import Commands from '@src/components/forms/Commands.vue';
 import PrunButton from '@src/components/PrunButton.vue';
 import Active from '@src/components/forms/Active.vue';
-import TextInput from '@src/components/forms/TextInput.vue';
 import NumberInput from '@src/components/forms/NumberInput.vue';
 import SelectInput from '@src/components/forms/SelectInput.vue';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 import { showTileOverlay, showConfirmationOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
 import removeArrayElement from '@src/utils/remove-array-element';
 import EditFlightrouteTransfer from '@src/features/XIT/FRP/EditFlightrouteTransfer.vue';
 
 const { action, add, onSave } = defineProps<{ action: UserData.FlightrouteAction; add?: boolean; onSave?: () => void }>();
 const emit = defineEmits<{ (e: 'close'): void }>();
+
+const destinationOptions = computed(() => {
+  const sites =
+    sitesStore.all.value?.map(site => ({
+      label: getEntityNameFromAddress(site.address) ?? site.siteId,
+      value: site.siteId,
+    })) ?? [];
+  const warehouses =
+    warehousesStore.all.value?.map(w => ({
+      label: getEntityNameFromAddress(w.address) ?? w.storeId,
+      value: w.storeId,
+    })) ?? [];
+  return [...sites, ...warehouses];
+});
 
 function addTransfer(ev: Event) {
   const transfer: UserData.Transfer = { ticker: '', direction: 'IN' };
@@ -47,7 +63,7 @@ function save() {
     <SectionHeader>{{ add ? 'Add' : 'Edit' }} Action</SectionHeader>
     <form>
       <Active label="Destination">
-        <TextInput v-model="action.destination" />
+        <SelectInput v-model="action.destination" :options="destinationOptions" />
       </Active>
       <Active label="Dump Cargo">
         <input type="checkbox" v-model="action.dumpCargo" />

--- a/src/features/XIT/FRP/EditFlightroutePlan.vue
+++ b/src/features/XIT/FRP/EditFlightroutePlan.vue
@@ -7,9 +7,23 @@ import Active from '@src/components/forms/Active.vue';
 import TextInput from '@src/components/forms/TextInput.vue';
 import removeArrayElement from '@src/utils/remove-array-element';
 import EditFlightrouteAction from '@src/features/XIT/FRP/EditFlightrouteAction.vue';
+import { vDraggable } from 'vue-draggable-plus';
+import grip from '@src/utils/grip.module.css';
+import fa from '@src/utils/font-awesome.module.css';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 
 const { plan, add, onSave } = defineProps<{ plan: UserData.FlightroutePlan; add?: boolean; onSave?: () => void }>();
 const emit = defineEmits<{ (e: 'close'): void }>();
+
+function destinationName(id: string) {
+  return (
+    getEntityNameFromAddress(sitesStore.getById(id)?.address) ??
+    getEntityNameFromAddress(warehousesStore.getById(id)?.address) ??
+    id
+  );
+}
 
 function addAction(ev: Event) {
   const action: UserData.FlightrouteAction = { destination: '', transfers: [] };
@@ -35,12 +49,24 @@ function save() {
   onSave?.();
   emit('close');
 }
+
+const dragging = ref(false);
+
+const draggableOptions = {
+  animation: 150,
+  handle: `.${grip.grip}`,
+  onStart: () => (dragging.value = true),
+  onEnd: () => (dragging.value = false),
+};
 </script>
 
 <template>
   <div :class="C.DraftConditionEditor.form">
     <SectionHeader>{{ add ? 'New' : 'Edit' }} Flight Plan</SectionHeader>
     <form>
+      <Active label="Name">
+        <TextInput v-model="plan.name" />
+      </Active>
       <table>
         <thead>
           <tr>
@@ -55,10 +81,16 @@ function save() {
             <td colspan="4" :class="$style.empty">No actions yet.</td>
           </tr>
         </tbody>
-        <tbody v-else>
+        <tbody
+          v-else
+          v-draggable="[plan.actions, draggableOptions]"
+          :class="dragging ? $style.dragging : null">
           <tr v-for="(action, i) in plan.actions" :key="i">
-            <td>{{ i + 1 }}</td>
-            <td>{{ action.destination }}</td>
+            <td>
+              <span :class="[grip.grip, fa.solid, $style.grip]">{{ '\uf58e' }}</span>
+              {{ i + 1 }}
+            </td>
+            <td>{{ destinationName(action.destination) }}</td>
             <td>
               <div v-if="action.dumpCargo">Dump Cargo</div>
               <div v-for="t in action.transfers" :key="t.ticker + t.direction">
@@ -85,5 +117,19 @@ function save() {
 <style module>
 .empty {
   text-align: center;
+}
+.grip {
+  cursor: move;
+  transition: opacity 0.2s ease-in-out;
+  opacity: 0;
+  margin-right: 5px;
+}
+
+tr:hover .grip {
+  opacity: 1;
+}
+
+.dragging td .grip {
+  opacity: 0;
 }
 </style>

--- a/src/features/XIT/FRP/EditFlightrouteTransfer.vue
+++ b/src/features/XIT/FRP/EditFlightrouteTransfer.vue
@@ -3,14 +3,19 @@ import SectionHeader from '@src/components/SectionHeader.vue';
 import Commands from '@src/components/forms/Commands.vue';
 import PrunButton from '@src/components/PrunButton.vue';
 import Active from '@src/components/forms/Active.vue';
-import TextInput from '@src/components/forms/TextInput.vue';
 import NumberInput from '@src/components/forms/NumberInput.vue';
-import SelectInput from '@src/components/forms/SelectInput.vue';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
 
 const { transfer, add, onSave } = defineProps<{ transfer: UserData.Transfer; add?: boolean; onSave?: () => void }>();
 const emit = defineEmits<{ (e: 'close'): void }>();
 
+const tickerOptions = computed(() => materialsStore.all.value?.map(m => m.ticker) ?? []);
+
 const directions: UserData.Direction[] = ['IN', 'OUT'];
+
+function selectDirection(dir: UserData.Direction) {
+  transfer.direction = dir;
+}
 
 function save() {
   onSave?.();
@@ -23,13 +28,25 @@ function save() {
     <SectionHeader>{{ add ? 'Add' : 'Edit' }} Transfer</SectionHeader>
     <form>
       <Active label="Ticker">
-        <TextInput v-model="transfer.ticker" />
+        <div>
+          <input list="tickers" v-model="transfer.ticker" />
+          <datalist id="tickers">
+            <option v-for="t in tickerOptions" :key="t" :value="t" />
+          </datalist>
+        </div>
       </Active>
       <Active label="Amount">
-        <NumberInput v-model="transfer.amount" />
+        <NumberInput v-model="transfer.amount" :min="0" :decimalPlaces="0" />
       </Active>
       <Active label="Direction">
-        <SelectInput v-model="transfer.direction" :options="directions" />
+        <PrunButton
+          v-for="dir in directions"
+          :key="dir"
+          :primary="transfer.direction === dir"
+          inline
+          @click="selectDirection(dir)">
+          {{ dir }}
+        </PrunButton>
       </Active>
       <Commands>
         <PrunButton primary @click="save">{{ add ? 'ADD' : 'DONE' }}</PrunButton>

--- a/src/features/XIT/FRP/FRP.vue
+++ b/src/features/XIT/FRP/FRP.vue
@@ -3,6 +3,9 @@ import { useXitParameters } from '@src/hooks/use-xit-parameters';
 import { userData } from '@src/store/user-data';
 import { isEmpty } from 'ts-extras';
 import FlightroutePlans from '@src/features/XIT/FRP/FlightroutePlans.vue';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 
 const parameters = useXitParameters();
 const routeId = parameters[0];
@@ -12,6 +15,14 @@ const route = computed(() => {
   return userData.flightRoutes.finished.find(r => r.id.startsWith(routeId));
 });
 const plan = computed(() => userData.flightRoutes.plans.find(p => p.id.startsWith(routeId)));
+
+function destinationName(id: string) {
+  return (
+    getEntityNameFromAddress(sitesStore.getById(id)?.address) ??
+    getEntityNameFromAddress(warehousesStore.getById(id)?.address) ??
+    id
+  );
+}
 </script>
 
 <template>
@@ -32,7 +43,7 @@ const plan = computed(() => userData.flightRoutes.plans.find(p => p.id.startsWit
           :class="{ current: index === route.state, done: index < route.state }"
         >
           <td>{{ index + 1 }}</td>
-          <td>{{ action.destination }}</td>
+          <td>{{ destinationName(action.destination) }}</td>
           <td>
             <div v-if="action.dumpCargo">Dump Cargo</div>
             <div v-for="t in action.transfers" :key="t.ticker + t.direction">
@@ -53,7 +64,7 @@ const plan = computed(() => userData.flightRoutes.plans.find(p => p.id.startsWit
       <tbody>
         <tr v-for="(action, index) in plan.actions" :key="index">
           <td>{{ index + 1 }}</td>
-          <td>{{ action.destination }}</td>
+          <td>{{ destinationName(action.destination) }}</td>
           <td>
             <div v-if="action.dumpCargo">Dump Cargo</div>
             <div v-for="t in action.transfers" :key="t.ticker + t.direction">

--- a/src/features/XIT/FRP/FlightroutePlans.vue
+++ b/src/features/XIT/FRP/FlightroutePlans.vue
@@ -12,7 +12,7 @@ import PrunLink from '@src/components/PrunLink.vue';
 import EditFlightroutePlan from '@src/features/XIT/FRP/EditFlightroutePlan.vue';
 
 function createNew(ev: Event) {
-  const plan: UserData.FlightroutePlan = { id: createId(), actions: [] };
+  const plan: UserData.FlightroutePlan = { id: createId(), name: '', actions: [] };
   showTileOverlay(ev, EditFlightroutePlan, {
     plan,
     add: true,
@@ -50,7 +50,7 @@ const draggableOptions = {
   <table>
     <thead>
       <tr>
-        <th>Id</th>
+        <th>Name</th>
         <th>Actions</th>
         <th />
       </tr>
@@ -62,7 +62,7 @@ const draggableOptions = {
         <td>
           <span :class="[grip.grip, fa.solid, $style.grip]">{{ '\uf58e' }}</span>
           <PrunLink inline :command="`XIT FRP ${plan.id.substring(0,8)}`">
-            {{ plan.id.substring(0, 8) }}
+            {{ plan.name || plan.id.substring(0, 8) }}
           </PrunLink>
         </td>
         <td>{{ plan.actions.length }}</td>

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -137,6 +137,7 @@ declare namespace UserData {
 
   interface FlightroutePlan {
     id: string;
+    name: string;
     actions: FlightrouteAction[];
   }
 


### PR DESCRIPTION
## Summary
- store a name with each flight route plan
- show and edit plan names
- display names for destinations
- drag & drop actions in plans
- select sites and stations as destinations
- enhance transfer editing with ticker filter, radio buttons, and numeric checks

## Testing
- `pnpm compile` *(fails: Request was cancelled)*
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684bf3e9a51c832586d46b7e98084655