### PR TITLE
Fix actions missing after creating flight plan

### DIFF
--- a/src/features/XIT/FRP/EditFlightroutePlan.vue
+++ b/src/features/XIT/FRP/EditFlightroutePlan.vue
@@ -14,7 +14,9 @@ import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addr
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 
-const { plan, add, onSave } = defineProps<{ plan: UserData.FlightroutePlan; add?: boolean; onSave?: () => void }>();
+const props = defineProps<{ plan: UserData.FlightroutePlan; add?: boolean; onSave?: () => void }>();
+const plan = reactive(props.plan);
+const { add, onSave } = props;
 const emit = defineEmits<{ (e: 'close'): void }>();
 
 function destinationName(id: string) {


### PR DESCRIPTION
## Summary
- convert flight plan prop to reactive data

## Testing
- `npm run lint` *(fails: Request was cancelled)*
- `npm run compile` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_684c1027180883258aa948c9ca2d53d5