### PR TITLE
Add flightplan start dialog

### DIFF
--- a/src/features/XIT/FRP/FRP.vue
+++ b/src/features/XIT/FRP/FRP.vue
@@ -6,6 +6,10 @@ import FlightroutePlans from '@src/features/XIT/FRP/FlightroutePlans.vue';
 import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import Commands from '@src/components/forms/Commands.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import StartFlightrouteOverlay from '@src/features/XIT/FRP/StartFlightrouteOverlay.vue';
 
 const parameters = useXitParameters();
 const routeId = parameters[0];
@@ -22,6 +26,12 @@ function destinationName(id: string) {
     getEntityNameFromAddress(warehousesStore.getById(id)?.address) ??
     id
   );
+}
+
+function openStart(ev: Event) {
+  const p = plan.value;
+  if (!p) return;
+  showTileOverlay(ev, StartFlightrouteOverlay, { plan: p });
 }
 </script>
 
@@ -74,6 +84,9 @@ function destinationName(id: string) {
         </tr>
       </tbody>
     </table>
+    <Commands v-if="plan">
+      <PrunButton primary @click="openStart">Start</PrunButton>
+    </Commands>
     <div v-else>No route found.</div>
   </div>
 </template>

--- a/src/features/XIT/FRP/StartFlightrouteOverlay.vue
+++ b/src/features/XIT/FRP/StartFlightrouteOverlay.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import SectionHeader from '@src/components/SectionHeader.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import Active from '@src/components/forms/Active.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
+import { getActiveByShipId } from '@src/store/flightroutes';
+import { flightplanController } from '@src/core/flightroute-controller';
+import { serializeShip } from '@src/features/XIT/ACT/actions/sfc/utils';
+
+const { plan } = defineProps<{ plan: UserData.FlightroutePlan }>();
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const shipOptions = computed(() => {
+  return (shipsStore.all.value ?? [])
+    .filter(s => !getActiveByShipId(s.id))
+    .map(s => ({ label: serializeShip(s), value: s.id }));
+});
+
+const selectedShip = ref('');
+
+watchEffect(() => {
+  if (!selectedShip.value && shipOptions.value.length > 0) {
+    selectedShip.value = shipOptions.value[0].value;
+  }
+});
+
+function start() {
+  if (!selectedShip.value) return;
+  flightplanController.startPlan(selectedShip.value, plan);
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>Start Flight Plan</SectionHeader>
+    <form>
+      <Active label="Ship">
+        <SelectInput v-model="selectedShip" :options="shipOptions" />
+      </Active>
+      <Commands>
+        <PrunButton primary @click="start">Start flightplan</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- allow starting a flightplan from the FRP table
- show new overlay to select a ship for the flightplan

## Testing
- `npm run lint` *(fails: Request was cancelled while fetching pnpm-9.4.0.tgz)*
- `npm run compile` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684c1222d19c83259a3790bd73895743