### PR TITLE
Add MTRA transfer helper and FRP test button

### DIFF
--- a/src/core/mtra-transfer.ts
+++ b/src/core/mtra-transfer.ts
@@ -1,0 +1,120 @@
+import { changeInputValue, clickElement, focusElement } from '@src/util';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { requestTile } from '@src/features/XIT/ACT/runner/tile-allocator';
+import { watchWhile } from '@src/utils/watch';
+import { isDefined } from 'ts-extras';
+
+export interface TransferMaterialOptions {
+  from: string;
+  to: string;
+  ticker: string;
+  amount: number;
+}
+
+export async function transferMaterialsViaMtra(options: TransferMaterialOptions) {
+  const { from, to, ticker: t, amount } = options;
+  const ticker = t.toUpperCase();
+  const fromStore = storagesStore.getById(from);
+  const toStore = storagesStore.getById(to);
+  if (!fromStore || !toStore) {
+    throw new Error('Origin or destination inventory not found');
+  }
+
+  const material = materialsStore.getByTicker(ticker);
+  if (!material) {
+    throw new Error(`Unknown material ${ticker}`);
+  }
+
+  const tile = await requestTile(
+    `MTRA from-${fromStore.id.substring(0, 8)} to-${toStore.id.substring(0, 8)}`,
+  );
+  if (!tile) return;
+
+  const container = await $(tile.anchor, C.MaterialSelector.container);
+  const input = await $(container, 'input');
+  const suggestionsContainer = await $(container, C.MaterialSelector.suggestionsContainer);
+  focusElement(input);
+  changeInputValue(input, ticker);
+
+  const suggestionsList = _$(container, C.MaterialSelector.suggestionsList);
+  if (!suggestionsList) {
+    throw new Error(`Ticker ${ticker} not found in the material selector`);
+  }
+  suggestionsContainer.style.display = 'none';
+  const match = _$$(suggestionsList, C.MaterialSelector.suggestionEntry).find(
+    x => _$(x, C.ColoredIcon.label)?.textContent === ticker,
+  );
+  if (!match) {
+    suggestionsContainer.style.display = '';
+    throw new Error(`Ticker ${ticker} not found in the material selector`);
+  }
+
+  await clickElement(match);
+  suggestionsContainer.style.display = '';
+
+  const sliderNumbers = _$$(tile.anchor, 'rc-slider-mark-text').map(x =>
+    Number(x.textContent ?? 0),
+  );
+  const maxAmount = Math.max(...sliderNumbers);
+  const allInputs = _$$<HTMLInputElement>(tile.anchor, 'input');
+  const amountInput = allInputs[1];
+  if (!amountInput) {
+    throw new Error('Missing amount input');
+  }
+  changeInputValue(amountInput, Math.min(amount, maxAmount).toString());
+
+  const transferButton = await $(tile.anchor, C.Button.btn);
+
+  const destinationAmount = computed(() => {
+    const store = storagesStore.getById(toStore.id);
+    return (
+      store?.items
+        .map(x => x.quantity ?? undefined)
+        .filter(isDefined)
+        .find(x => x.material.ticker === ticker)?.amount ?? 0
+    );
+  });
+  const currentAmount = destinationAmount.value;
+
+  await clickElement(transferButton);
+  await waitActionFeedback(tile);
+  await watchWhile(() => destinationAmount.value === currentAmount);
+}
+
+async function waitActionFeedback(tile: PrunTile) {
+  const overlay = await $(tile.frame, C.ActionFeedback.overlay);
+  await waitActionProgress(overlay);
+  if (overlay.classList.contains(C.ActionConfirmationOverlay.container)) {
+    const confirm = _$$(overlay, C.Button.btn)[1];
+    if (confirm === undefined) {
+      throw new Error('Confirmation overlay is missing confirm button');
+    }
+    await clickElement(confirm);
+    await waitActionProgress(overlay);
+  }
+  if (overlay.classList.contains(C.ActionFeedback.success)) {
+    await clickElement(overlay);
+    return;
+  }
+  if (overlay.classList.contains(C.ActionFeedback.error)) {
+    const message = _$(overlay, C.ActionFeedback.message)?.textContent;
+    const dismiss = _$(overlay, C.ActionFeedback.dismiss)?.textContent;
+    throw new Error(dismiss ? message?.replace(dismiss, '') ?? '' : message ?? '');
+  }
+}
+
+async function waitActionProgress(overlay: HTMLElement) {
+  if (!overlay.classList.contains(C.ActionFeedback.progress)) {
+    return;
+  }
+  await new Promise<void>(resolve => {
+    const mutationObserver = new MutationObserver(() => {
+      if (!overlay.classList.contains(C.ActionFeedback.progress)) {
+        mutationObserver.disconnect();
+        resolve();
+      }
+    });
+    mutationObserver.observe(overlay, { attributes: true });
+  });
+}

--- a/src/features/XIT/FRP/FRP.vue
+++ b/src/features/XIT/FRP/FRP.vue
@@ -10,6 +10,7 @@ import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
 import Commands from '@src/components/forms/Commands.vue';
 import PrunButton from '@src/components/PrunButton.vue';
 import StartFlightrouteOverlay from '@src/features/XIT/FRP/StartFlightrouteOverlay.vue';
+import TestTransferOverlay from '@src/features/XIT/FRP/TestTransferOverlay.vue';
 
 const parameters = useXitParameters();
 const routeId = parameters[0];
@@ -33,6 +34,10 @@ function openStart(ev: Event) {
   if (!p) return;
   showTileOverlay(ev, StartFlightrouteOverlay, { plan: p });
 }
+
+function testTransfers(ev: Event, action: UserData.FlightrouteAction) {
+  showTileOverlay(ev, TestTransferOverlay, { action });
+}
 </script>
 
 <template>
@@ -44,6 +49,7 @@ function openStart(ev: Event) {
           <th>#</th>
           <th>Destination</th>
           <th>Transfers</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -60,6 +66,9 @@ function openStart(ev: Event) {
               {{ t.direction }} {{ t.amount ?? 'ALL' }} {{ t.ticker }}
             </div>
           </td>
+          <td>
+            <PrunButton dark inline @click="testTransfers($event, action)">test</PrunButton>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -69,6 +78,7 @@ function openStart(ev: Event) {
           <th>#</th>
           <th>Destination</th>
           <th>Transfers</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -80,6 +90,9 @@ function openStart(ev: Event) {
             <div v-for="t in action.transfers" :key="t.ticker + t.direction">
               {{ t.direction }} {{ t.amount ?? 'ALL' }} {{ t.ticker }}
             </div>
+          </td>
+          <td>
+            <PrunButton dark inline @click="testTransfers($event, action)">test</PrunButton>
           </td>
         </tr>
       </tbody>

--- a/src/features/XIT/FRP/TestTransferOverlay.vue
+++ b/src/features/XIT/FRP/TestTransferOverlay.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import SectionHeader from '@src/components/SectionHeader.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import Active from '@src/components/forms/Active.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { getActiveByShipId } from '@src/store/flightroutes';
+import { serializeShip } from '@src/features/XIT/ACT/actions/sfc/utils';
+import { transferMaterialsViaMtra } from '@src/core/mtra-transfer';
+
+const { action } = defineProps<{ action: UserData.FlightrouteAction }>();
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const shipOptions = computed(() => {
+  return (shipsStore.all.value ?? [])
+    .filter(s => !getActiveByShipId(s.id))
+    .map(s => ({ label: serializeShip(s), value: s.id }));
+});
+
+const selectedShip = ref('');
+
+watchEffect(() => {
+  if (!selectedShip.value && shipOptions.value.length > 0) {
+    selectedShip.value = shipOptions.value[0].value;
+  }
+});
+
+async function execute() {
+  if (!selectedShip.value) return;
+  const shipStore = storagesStore
+    .getByAddressableId(selectedShip.value)
+    ?.find(s => s.type === 'SHIP_STORE');
+  const destStore = storagesStore
+    .getByAddressableId(action.destination)
+    ?.find(s => s.type === 'STORE' || s.type === 'WAREHOUSE_STORE');
+  if (!shipStore || !destStore) return;
+
+  for (const t of action.transfers ?? []) {
+    const from = t.direction === 'IN' ? destStore.id : shipStore.id;
+    const to = t.direction === 'IN' ? shipStore.id : destStore.id;
+    const amount = t.amount ?? Number.MAX_SAFE_INTEGER;
+    await transferMaterialsViaMtra({ from, to, ticker: t.ticker.toUpperCase(), amount });
+  }
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>Execute Transfers</SectionHeader>
+    <form>
+      <Active label="Ship">
+        <SelectInput v-model="selectedShip" :options="shipOptions" />
+      </Active>
+      <Commands>
+        <PrunButton primary @click="execute">RUN</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- provide `transferMaterialsViaMtra` helper to reuse MTRA buffer logic
- add overlay to run transfers of a flightroute action with a chosen ship
- show **Test** button per action in the flight route plan dialog

## Testing
- `npm run compile` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684c19ddf47c8325b2073a8870bf163b